### PR TITLE
Optimize shuffle cache

### DIFF
--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
@@ -42,7 +42,7 @@ import tech.pegasys.artemis.datastructures.state.BeaconState;
 
 public class CommitteeUtil {
 
-  private static int MAX_SHUFFLE_CACHE = 64;
+  public static int MAX_SHUFFLE_CACHE = 64;
 
   private static class ShuffleKey {
     private final int index_count;

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
@@ -55,8 +55,7 @@ public class CommitteeUtil {
     @Override
     public boolean equals(Object o) {
       ShuffleKey that = (ShuffleKey) o;
-      return index_count == that.index_count &&
-          seed.equals(that.seed);
+      return index_count == that.index_count && seed.equals(that.seed);
     }
 
     @Override
@@ -66,10 +65,7 @@ public class CommitteeUtil {
 
     @Override
     public String toString() {
-      return "ShuffleKey{" +
-          "index_count=" + index_count +
-          ", seed=" + seed +
-          '}';
+      return "ShuffleKey{" + "index_count=" + index_count + ", seed=" + seed + '}';
     }
   }
 
@@ -89,8 +85,11 @@ public class CommitteeUtil {
   public static Integer compute_shuffled_index(int index, int index_count, Bytes32 seed) {
     checkArgument(index < index_count, "CommitteeUtil.get_shuffled_index1");
 
-    Integer[] cachedShuffle = MAX_SHUFFLE_CACHE == 0 ? null : shuffleCache
-        .computeIfAbsent(new ShuffleKey(index_count, seed), k -> new Integer[k.index_count]);
+    Integer[] cachedShuffle =
+        MAX_SHUFFLE_CACHE == 0
+            ? null
+            : shuffleCache.computeIfAbsent(
+                new ShuffleKey(index_count, seed), k -> new Integer[k.index_count]);
 
     if (cachedShuffle != null && cachedShuffle[index] != null) {
       return cachedShuffle[index];

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/CommitteeUtil.java
@@ -29,16 +29,15 @@ import static tech.pegasys.artemis.util.config.Constants.SLOTS_PER_EPOCH;
 import com.google.common.primitives.UnsignedBytes;
 import com.google.common.primitives.UnsignedLong;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.Hash;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
+import tech.pegasys.artemis.util.collections.LimitedHashMap;
 
 public class CommitteeUtil {
 
@@ -74,21 +73,8 @@ public class CommitteeUtil {
     }
   }
 
-  private static class LimitedHashMap<K, V> extends LinkedHashMap<K, V> {
-    private final int maxSize;
-
-    public LimitedHashMap(int maxSize) {
-      this.maxSize = maxSize;
-    }
-
-    @Override
-    protected boolean removeEldestEntry(Entry<K, V> eldest) {
-      return size() > maxSize;
-    }
-  }
-
-  private final static Map<ShuffleKey, Integer[]> shuffleCache = Collections.synchronizedMap(
-      new LimitedHashMap<>(MAX_SHUFFLE_CACHE));
+  public static final Map<ShuffleKey, Integer[]> shuffleCache =
+      Collections.synchronizedMap(new LimitedHashMap<>(MAX_SHUFFLE_CACHE));
 
   /**
    * Return the shuffled validator index corresponding to ``seed`` (and ``index_count``).

--- a/util/src/main/java/tech/pegasys/artemis/util/collections/LimitedHashMap.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/collections/LimitedHashMap.java
@@ -1,11 +1,22 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.artemis.util.collections;
 
 import java.util.LinkedHashMap;
 import java.util.Map.Entry;
 
-/**
- * Map with limited capacity. When map size overflows max capacity the eldest entry is dropped
- */
+/** Map with limited capacity. When map size overflows max capacity the eldest entry is dropped */
 public class LimitedHashMap<K, V> extends LinkedHashMap<K, V> {
   private final int maxSize;
 

--- a/util/src/main/java/tech/pegasys/artemis/util/collections/LimitedHashMap.java
+++ b/util/src/main/java/tech/pegasys/artemis/util/collections/LimitedHashMap.java
@@ -1,0 +1,20 @@
+package tech.pegasys.artemis.util.collections;
+
+import java.util.LinkedHashMap;
+import java.util.Map.Entry;
+
+/**
+ * Map with limited capacity. When map size overflows max capacity the eldest entry is dropped
+ */
+public class LimitedHashMap<K, V> extends LinkedHashMap<K, V> {
+  private final int maxSize;
+
+  public LimitedHashMap(int maxSize) {
+    this.maxSize = maxSize;
+  }
+
+  @Override
+  protected boolean removeEldestEntry(Entry<K, V> eldest) {
+    return size() > maxSize;
+  }
+}


### PR DESCRIPTION
## PR Description

The most low hanging fruit for epoch transition performance: shuffling is expensive and invoked pretty frequently, while its result depends only on the seed which is constant for a block. 

The solution is to add a cache `(seed, index_count) -> [shuffle_idx(0), shuffle_idx(1), ..., shuffle_idx(index_count - 1)]` to `compute_shuffled_index` function.

In the current spec a `seed` argument uniquely identify `index_count` argument so the cache key may be defined as just `(seed)`. However the `compute_shuffled_index` function has more generic nature and can potentially be used in other scenarios. So it seems safer to include the `index_count` to the cache key.

## Results
Optimization yields ~10x epoch transition performance boost

Before optimization: 
```
Benchmark                              (validatorsCount)  Mode  Cnt    Score   Error  Units
TransitionBenchmark.Block.importBlock               1024    ss   50    0,348 ± 0,004   s/op
TransitionBenchmark.Block.importBlock               3072    ss   50    0,570 ± 0,017   s/op
TransitionBenchmark.Epoch.importBlock               1024    ss   10   22,303 ± 0,466   s/op
TransitionBenchmark.Epoch.importBlock               3072    ss   10  196,323 ± 3,707   s/op
```

After optimization: 
```
Benchmark                              (validatorsCount)  Mode  Cnt   Score   Error  Units
TransitionBenchmark.Block.importBlock               1024    ss   50   0,352 ± 0,004   s/op
TransitionBenchmark.Block.importBlock               3072    ss   50   0,527 ± 0,003   s/op
TransitionBenchmark.Epoch.importBlock               1024    ss   10   2,053 ± 0,035   s/op
TransitionBenchmark.Epoch.importBlock               3072    ss   10  16,164 ± 0,146   s/op
```