### PR TITLE
Optimize active validators cache

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/TransitionBenchmark.java
@@ -35,6 +35,8 @@ import tech.pegasys.artemis.benchmarks.gen.BlockIO;
 import tech.pegasys.artemis.benchmarks.gen.BlsKeyPairIO;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.util.BeaconStateUtil;
+import tech.pegasys.artemis.datastructures.util.CommitteeUtil;
+import tech.pegasys.artemis.datastructures.util.ValidatorsUtil;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImportResult;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImporter;
@@ -88,7 +90,10 @@ public abstract class TransitionBenchmark {
   }
 
   @TearDown
-  public void dispose() throws Exception {}
+  public void dispose() throws Exception {
+    CommitteeUtil.shuffleCache.clear();
+    ValidatorsUtil.activeValidatorsCache.clear();
+  }
 
   protected void prefetchBlock() {
     prefetchedBlock = blockIterator.next();

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/ValidatorsUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/ValidatorsUtil.java
@@ -30,7 +30,7 @@ public class ValidatorsUtil {
 
   public static int MAX_ACTIVE_VALIDATORS_CACHE = 64;
 
-  public static Map<UnsignedLong, List<Integer>> activeValidatorsCache =
+  public static final Map<UnsignedLong, List<Integer>> activeValidatorsCache =
       Collections.synchronizedMap(new LimitedHashMap<>(MAX_ACTIVE_VALIDATORS_CACHE));
 
   /**

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/ValidatorsUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/ValidatorsUtil.java
@@ -16,14 +16,22 @@ package tech.pegasys.artemis.datastructures.util;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
 import tech.pegasys.artemis.datastructures.state.Validator;
+import tech.pegasys.artemis.util.collections.LimitedHashMap;
 
 public class ValidatorsUtil {
+
+  public static int MAX_ACTIVE_VALIDATORS_CACHE = 64;
+
+  public static Map<UnsignedLong, List<Integer>> activeValidatorsCache =
+      Collections.synchronizedMap(new LimitedHashMap<>(MAX_ACTIVE_VALIDATORS_CACHE));
 
   /**
    * Check if (this) validator is active in the given epoch.
@@ -72,10 +80,13 @@ public class ValidatorsUtil {
    */
   public static List<Integer> get_active_validator_indices(BeaconState state, UnsignedLong epoch) {
     List<Validator> validators = state.getValidators();
-    return IntStream.range(0, validators.size())
-        .filter(index -> is_active_validator(validators.get(index), epoch))
-        .boxed()
-        .collect(Collectors.toList());
+    return activeValidatorsCache.computeIfAbsent(
+        epoch,
+        e ->
+            IntStream.range(0, validators.size())
+                .filter(index -> is_active_validator(validators.get(index), epoch))
+                .boxed()
+                .collect(Collectors.toList()));
   }
 
   /**


### PR DESCRIPTION
## PR Description

**WARN:** this is not quite correct cache implementation, since the `epoch` is not the unique key in case of forks.

`get_active_validator_indices` is frequently invoked while its return value is persistent within an epoch. So we need another cache here. 

## Results

While there is another 5x-7x epoch processing performance boost the quadratic complexity (of validator count) may still be observed:
```
(validatorsCount)   Score
             1024   0,613
             3072   2,704
            10240  28,404
```
#### Before
```
Benchmark                              (validatorsCount)  Mode  Cnt   Score   Error  Units
TransitionBenchmark.Block.importBlock               1024    ss   50   0,352 ± 0,004   s/op
TransitionBenchmark.Block.importBlock               3072    ss   50   0,527 ± 0,003   s/op
TransitionBenchmark.Epoch.importBlock               1024    ss   10   2,053 ± 0,035   s/op
TransitionBenchmark.Epoch.importBlock               3072    ss   10  16,164 ± 0,146   s/op
```
#### After
```
Benchmark                              (validatorsCount)  Mode  Cnt  Score   Error  Units
TransitionBenchmark.Block.importBlock               1024    ss   50  0,351 ± 0,009   s/op
TransitionBenchmark.Block.importBlock               3072    ss   50  0,529 ± 0,005   s/op
TransitionBenchmark.Block.importBlock              10240    ss   50  1,135 ± 0,020   s/op
TransitionBenchmark.Epoch.importBlock               1024    ss   10  0,613 ± 0,011   s/op
TransitionBenchmark.Epoch.importBlock               3072    ss   10  2,704 ± 0,090   s/op
TransitionBenchmark.Epoch.importBlock              10240    ss   10 28,404 ± 3,693   s/op
```