### PR TITLE
Optimize: parallelize block attestations validation

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/artemis/statetransition/util/BlockProcessorUtil.java
@@ -395,12 +395,18 @@ public final class BlockProcessorUtil {
               "process_attestations: Attestation source error 2");
           state.getPrevious_epoch_attestations().add(pendingAttestation);
         }
-
-        // Check signature
-        checkArgument(
-            is_valid_indexed_attestation(state, get_indexed_attestation(state, attestation)),
-            "process_attestations: Check signature");
       }
+
+      attestations.stream()
+          .parallel()
+          .forEach(
+              attestation -> {
+                // Check signature
+                checkArgument(
+                    is_valid_indexed_attestation(
+                        state, get_indexed_attestation(state, attestation)),
+                    "process_attestations: Check signature");
+              });
     } catch (IllegalArgumentException e) {
       STDOUT.log(Level.WARN, e.getMessage());
       throw new BlockProcessingException(e);


### PR DESCRIPTION
## PR Description

BLS signature validation is heavy and takes ~95% of block import. The most easy and straightforward optimization is to parallelize block attestations validation 

## Results
Blocks import speed increased on ~50% 

#### Before
```
Benchmark                              (validatorsCount)  Mode  Cnt  Score   Error  Units
TransitionBenchmark.Block.importBlock               1024    ss   50  0,351 ± 0,009   s/op
TransitionBenchmark.Block.importBlock               3072    ss   50  0,529 ± 0,005   s/op
TransitionBenchmark.Epoch.importBlock               1024    ss   10  0,613 ± 0,011   s/op
TransitionBenchmark.Epoch.importBlock               3072    ss   10  2,704 ± 0,090   s/op
```

#### After
```
Benchmark                              (validatorsCount)  Mode  Cnt  Score   Error  Units
TransitionBenchmark.Block.importBlock               1024    ss   50  0,226 ± 0,009   s/op
TransitionBenchmark.Block.importBlock               3072    ss   50  0,352 ± 0,004   s/op
TransitionBenchmark.Epoch.importBlock               1024    ss   10  0,484 ± 0,009   s/op
TransitionBenchmark.Epoch.importBlock               3072    ss   10  2,544 ± 0,053   s/op
```