### PR TITLE
Optimize: move caches to the beacon state

### DIFF
--- a/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/TransitionBenchmark.java
+++ b/eth-benchmark-tests/src/jmh/java/tech/pegasys/artemis/benchmarks/TransitionBenchmark.java
@@ -36,7 +36,6 @@ import tech.pegasys.artemis.benchmarks.gen.BlsKeyPairIO;
 import tech.pegasys.artemis.datastructures.blocks.BeaconBlock;
 import tech.pegasys.artemis.datastructures.util.BeaconStateUtil;
 import tech.pegasys.artemis.datastructures.util.CommitteeUtil;
-import tech.pegasys.artemis.datastructures.util.ValidatorsUtil;
 import tech.pegasys.artemis.statetransition.BeaconChainUtil;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImportResult;
 import tech.pegasys.artemis.statetransition.blockimport.BlockImporter;
@@ -92,7 +91,6 @@ public abstract class TransitionBenchmark {
   @TearDown
   public void dispose() throws Exception {
     CommitteeUtil.shuffleCache.clear();
-    ValidatorsUtil.activeValidatorsCache.clear();
   }
 
   protected void prefetchBlock() {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconStateWithCache.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/BeaconStateWithCache.java
@@ -25,8 +25,11 @@ import tech.pegasys.artemis.util.SSZTypes.SSZVector;
 
 public final class BeaconStateWithCache extends BeaconState {
 
+  private final TransitionCaches transitionCaches;
+
   public BeaconStateWithCache() {
     super();
+    transitionCaches = TransitionCaches.createNewEmpty();
   }
 
   public BeaconStateWithCache(
@@ -86,6 +89,53 @@ public final class BeaconStateWithCache extends BeaconState {
         previous_justified_checkpoint,
         current_justified_checkpoint,
         finalized_checkpoint);
+    transitionCaches = TransitionCaches.createNewEmpty();
+  }
+
+  private BeaconStateWithCache(
+      UnsignedLong genesis_time,
+      UnsignedLong slot,
+      Fork fork,
+      BeaconBlockHeader latest_block_header,
+      SSZVector<Bytes32> block_roots,
+      SSZVector<Bytes32> state_roots,
+      SSZList<Bytes32> historical_roots,
+      Eth1Data eth1_data,
+      SSZList<Eth1Data> eth1_data_votes,
+      UnsignedLong eth1_deposit_index,
+      SSZList<Validator> validators,
+      SSZList<UnsignedLong> balances,
+      SSZVector<Bytes32> randao_mixes,
+      SSZVector<UnsignedLong> slashings,
+      SSZList<PendingAttestation> previous_epoch_attestations,
+      SSZList<PendingAttestation> current_epoch_attestations,
+      Bitvector justification_bits,
+      Checkpoint previous_justified_checkpoint,
+      Checkpoint current_justified_checkpoint,
+      Checkpoint finalized_checkpoint,
+      TransitionCaches transitionCaches) {
+    super(
+        genesis_time,
+        slot,
+        fork,
+        latest_block_header,
+        block_roots,
+        state_roots,
+        historical_roots,
+        eth1_data,
+        eth1_data_votes,
+        eth1_deposit_index,
+        validators,
+        balances,
+        randao_mixes,
+        slashings,
+        previous_epoch_attestations,
+        current_epoch_attestations,
+        justification_bits,
+        previous_justified_checkpoint,
+        current_justified_checkpoint,
+        finalized_checkpoint);
+    this.transitionCaches = transitionCaches;
   }
 
   public static BeaconStateWithCache deepCopy(BeaconState state) {
@@ -138,7 +188,10 @@ public final class BeaconStateWithCache extends BeaconState {
         state.getJustification_bits().copy(),
         state.getPrevious_justified_checkpoint(),
         state.getCurrent_justified_checkpoint(),
-        state.getFinalized_checkpoint());
+        state.getFinalized_checkpoint(),
+        state instanceof BeaconStateWithCache
+            ? ((BeaconStateWithCache) state).transitionCaches.copy()
+            : TransitionCaches.createNewEmpty());
   }
 
   /**
@@ -170,6 +223,16 @@ public final class BeaconStateWithCache extends BeaconState {
         state.getPrevious_justified_checkpoint(),
         state.getCurrent_justified_checkpoint(),
         state.getFinalized_checkpoint());
+  }
+
+  public static TransitionCaches getTransitionCaches(BeaconState state) {
+    return state instanceof BeaconStateWithCache
+        ? ((BeaconStateWithCache) state).getTransitionCaches()
+        : TransitionCaches.getNoOp();
+  }
+
+  public TransitionCaches getTransitionCaches() {
+    return transitionCaches;
   }
 
   private static <S extends Copyable<S>, T extends List<S>> T copyList(

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/TransitionCaches.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/TransitionCaches.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.state;
+
+import com.google.common.primitives.UnsignedLong;
+import java.util.List;
+import tech.pegasys.artemis.datastructures.util.cache.Cache;
+import tech.pegasys.artemis.datastructures.util.cache.LRUCache;
+import tech.pegasys.artemis.datastructures.util.cache.NoOpCache;
+
+public class TransitionCaches {
+
+  private static final TransitionCaches NO_OP_INSTANCE =
+      new TransitionCaches(NoOpCache.getNoOpCache()) {
+
+        @Override
+        public TransitionCaches copy() {
+          return this;
+        }
+      };
+
+  public static TransitionCaches createNewEmpty() {
+    return new TransitionCaches();
+  }
+
+  public static TransitionCaches getNoOp() {
+    return NO_OP_INSTANCE;
+  }
+
+  private final Cache<UnsignedLong, List<Integer>> activeValidators;
+
+  private TransitionCaches() {
+    activeValidators = new LRUCache<>(8);
+  }
+
+  private TransitionCaches(Cache<UnsignedLong, List<Integer>> activeValidators) {
+    this.activeValidators = activeValidators;
+  }
+
+  public Cache<UnsignedLong, List<Integer>> getActiveValidators() {
+    return activeValidators;
+  }
+
+  public TransitionCaches copy() {
+    return new TransitionCaches(activeValidators.copy());
+  }
+}

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/TransitionCaches.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/state/TransitionCaches.java
@@ -21,6 +21,8 @@ import tech.pegasys.artemis.datastructures.util.cache.NoOpCache;
 
 public class TransitionCaches {
 
+  public static int MAX_ACTIVE_VALIDATORS_CACHE = 8;
+
   private static final TransitionCaches NO_OP_INSTANCE =
       new TransitionCaches(NoOpCache.getNoOpCache()) {
 
@@ -41,7 +43,7 @@ public class TransitionCaches {
   private final Cache<UnsignedLong, List<Integer>> activeValidators;
 
   private TransitionCaches() {
-    activeValidators = new LRUCache<>(8);
+    activeValidators = new LRUCache<>(MAX_ACTIVE_VALIDATORS_CACHE);
   }
 
   private TransitionCaches(Cache<UnsignedLong, List<Integer>> activeValidators) {

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/ValidatorsUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/ValidatorsUtil.java
@@ -16,22 +16,15 @@ package tech.pegasys.artemis.datastructures.util;
 import com.google.common.collect.Sets;
 import com.google.common.primitives.UnsignedLong;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import tech.pegasys.artemis.datastructures.state.BeaconState;
+import tech.pegasys.artemis.datastructures.state.BeaconStateWithCache;
 import tech.pegasys.artemis.datastructures.state.Validator;
-import tech.pegasys.artemis.util.collections.LimitedHashMap;
 
 public class ValidatorsUtil {
-
-  public static int MAX_ACTIVE_VALIDATORS_CACHE = 64;
-
-  public static final Map<UnsignedLong, List<Integer>> activeValidatorsCache =
-      Collections.synchronizedMap(new LimitedHashMap<>(MAX_ACTIVE_VALIDATORS_CACHE));
 
   /**
    * Check if (this) validator is active in the given epoch.
@@ -79,14 +72,17 @@ public class ValidatorsUtil {
    *     <a>https://github.com/ethereum/eth2.0-specs/blob/v0.8.0/specs/core/0_beacon-chain.md#get_active_validator_indices</a>
    */
   public static List<Integer> get_active_validator_indices(BeaconState state, UnsignedLong epoch) {
-    List<Validator> validators = state.getValidators();
-    return activeValidatorsCache.computeIfAbsent(
-        epoch,
-        e ->
-            IntStream.range(0, validators.size())
-                .filter(index -> is_active_validator(validators.get(index), epoch))
-                .boxed()
-                .collect(Collectors.toList()));
+    return BeaconStateWithCache.getTransitionCaches(state)
+        .getActiveValidators()
+        .get(
+            epoch,
+            e -> {
+              List<Validator> validators = state.getValidators();
+              return IntStream.range(0, validators.size())
+                  .filter(index -> is_active_validator(validators.get(index), epoch))
+                  .boxed()
+                  .collect(Collectors.toList());
+            });
   }
 
   /**

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/cache/Cache.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/cache/Cache.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.util.cache;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Cache
+ *
+ * @param <K> type of keys
+ * @param <V> type of values
+ */
+public interface Cache<K, V> {
+  /**
+   * Queries value from the cache. If it's not found there, fallback function is used to calculate
+   * value. After calculation result is put in cache and returned.
+   *
+   * @param key Key to query
+   * @param fallback Fallback function for calculation of the result in case of missed cache entry
+   * @return expected value result for provided key
+   */
+  V get(K key, Function<K, V> fallback);
+
+  /**
+   * Optionally returns the value corresponding to the passed <code>key</code> is it's in the cache
+   */
+  Optional<V> getCached(K key);
+
+  /** Creates independent copy of this Cache instance */
+  Cache<K, V> copy();
+}

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/cache/LRUCache.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/cache/LRUCache.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.util.cache;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Cache made around LRU-map with fixed size, removing eldest entries (by added) when the space is
+ * over
+ *
+ * @param <K> Keys type
+ * @param <V> Values type
+ */
+public class LRUCache<K, V> implements Cache<K, V> {
+
+  private final Map<K, V> cacheData;
+  private final int maxCapacity;
+
+  /**
+   * Creates cache
+   *
+   * @param capacity Size of the cache
+   */
+  public LRUCache(int capacity) {
+    this(capacity, Collections.emptyMap());
+  }
+
+  private LRUCache(int capacity, Map<K, V> initialCachedContent) {
+    this.maxCapacity = capacity;
+    this.cacheData =
+        Collections.synchronizedMap(
+            new LinkedHashMap<K, V>(maxCapacity + 1, .75F, true) {
+              {
+                putAll(initialCachedContent);
+              }
+              // This method is called just after a new entry has been added
+              public boolean removeEldestEntry(Map.Entry eldest) {
+                return size() > maxCapacity;
+              }
+            });
+  }
+
+  @Override
+  public Cache<K, V> copy() {
+    return new LRUCache<>(maxCapacity, cacheData);
+  }
+
+  /**
+   * Queries value from the cache. If it's not found there, fallback function is used to calculate
+   * value. After calculation result is put in cache and returned.
+   *
+   * @param key Key to query
+   * @param fallback Fallback function for calculation of the result in case of missed cache entry
+   * @return expected value result for provided key
+   */
+  @Override
+  public V get(K key, Function<K, V> fallback) {
+    V result = cacheData.get(key);
+
+    if (result == null) {
+      result = fallback.apply(key);
+      cacheData.put(key, result);
+    }
+
+    return result;
+  }
+
+  public Optional<V> getCached(K key) {
+    return Optional.ofNullable(cacheData.get(key));
+  }
+}

--- a/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/cache/NoOpCache.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/artemis/datastructures/util/cache/NoOpCache.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.artemis.datastructures.util.cache;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Cache without cache proxying all requests to fallback function
+ *
+ * @param <K> Keys type
+ * @param <V> Values type
+ */
+public class NoOpCache<K, V> implements Cache<K, V> {
+
+  private static final NoOpCache INSTANCE = new NoOpCache();
+
+  public static <K, V> Cache<K, V> getNoOpCache() {
+    return INSTANCE;
+  }
+
+  /** Creates cache */
+  private NoOpCache() {}
+
+  /**
+   * Just calls fallback to calculate result and returns it as it's mock cache
+   *
+   * @param key Key to query
+   * @param fallback Fallback function for calculation of the result
+   * @return expected value result for provided key
+   */
+  @Override
+  public V get(K key, Function<K, V> fallback) {
+    return fallback.apply(key);
+  }
+
+  @Override
+  public Optional<V> getCached(K key) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Cache<K, V> copy() {
+    return this;
+  }
+}


### PR DESCRIPTION
## PR Description

This is an effort to address drawbacks of transition cache like in this PR #2 
- static cache objects 
- we need to track correctly keys which may be not unique across epoch boundary forks 
- all caches need to cleared between different test runs (else they can be invalid)

The general idea is to keep all transition-related caches inside `BeaconStateWithCache` in a separate `TransitionCaches` class. On `BeaconState` copy all caches are also copied to avoid caches conflicts between forks
Generally these caches would behave like 'historical' `BeaconState` data members.
This solution would also isolate test-to-test caches 
