### PR TITLE
Replace BeaconState.block_roots and HistoricalBatch.getBlockRoots with SszPrimitiveVector

### DIFF
--- a/data/serializer/src/main/java/tech/pegasys/teku/api/schema/BeaconState.java
+++ b/data/serializer/src/main/java/tech/pegasys/teku/api/schema/BeaconState.java
@@ -142,7 +142,7 @@ public class BeaconState {
     this.slot = beaconState.getSlot();
     this.fork = new Fork(beaconState.getFork());
     this.latest_block_header = new BeaconBlockHeader(beaconState.getLatest_block_header());
-    this.block_roots = beaconState.getBlock_roots().stream().collect(Collectors.toList());
+    this.block_roots = beaconState.getBlock_roots().streamUnboxed().collect(Collectors.toList());
     this.state_roots = beaconState.getState_roots().stream().collect(Collectors.toList());
     this.historical_roots = beaconState.getHistorical_roots().stream().collect(Collectors.toList());
     this.eth1_data = new Eth1Data(beaconState.getEth1_data());
@@ -177,7 +177,9 @@ public class BeaconState {
         slot,
         fork.asInternalFork(),
         latest_block_header.asInternalBeaconBlockHeader(),
-        SSZVector.createMutable(block_roots, Bytes32.class),
+        tech.pegasys.teku.datastructures.state.BeaconState.BLOCK_ROOTS_FIELD_SCHEMA
+            .get()
+            .of(block_roots),
         SSZVector.createMutable(state_roots, Bytes32.class),
         SSZList.createMutable(historical_roots, HISTORICAL_ROOTS_LIMIT, Bytes32.class),
         eth1_data.asInternalEth1Data(),

--- a/ethereum/core/src/main/java/tech/pegasys/teku/core/StateTransition.java
+++ b/ethereum/core/src/main/java/tech/pegasys/teku/core/StateTransition.java
@@ -172,7 +172,7 @@ public class StateTransition {
 
           // Cache block root
           Bytes32 previous_block_root = state.getLatest_block_header().hashTreeRoot();
-          state.getBlock_roots().set(index, previous_block_root);
+          state.getBlock_roots().setElement(index, previous_block_root);
         });
   }
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/BeaconStateImpl.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/BeaconStateImpl.java
@@ -27,10 +27,12 @@ import tech.pegasys.teku.ssz.backing.SszList;
 import tech.pegasys.teku.ssz.backing.cache.IntCache;
 import tech.pegasys.teku.ssz.backing.cache.SoftRefIntCache;
 import tech.pegasys.teku.ssz.backing.collections.SszBitvector;
+import tech.pegasys.teku.ssz.backing.collections.SszPrimitiveVector;
 import tech.pegasys.teku.ssz.backing.schema.SszCompositeSchema;
 import tech.pegasys.teku.ssz.backing.schema.impl.AbstractSszContainerSchema;
 import tech.pegasys.teku.ssz.backing.tree.TreeNode;
 import tech.pegasys.teku.ssz.backing.view.SszContainerImpl;
+import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszBytes32;
 
 class BeaconStateImpl extends SszContainerImpl implements BeaconState, BeaconStateCache {
 
@@ -64,7 +66,7 @@ class BeaconStateImpl extends SszContainerImpl implements BeaconState, BeaconSta
 
       // History
       BeaconBlockHeader latest_block_header,
-      SSZVector<Bytes32> block_roots,
+      SszPrimitiveVector<Bytes32, SszBytes32> block_roots,
       SSZVector<Bytes32> state_roots,
       SSZList<Bytes32> historical_roots,
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/HistoricalBatch.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/HistoricalBatch.java
@@ -17,10 +17,12 @@ import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.ssz.SSZTypes.SSZBackingVector;
 import tech.pegasys.teku.ssz.SSZTypes.SSZVector;
 import tech.pegasys.teku.ssz.backing.SszVector;
+import tech.pegasys.teku.ssz.backing.collections.SszPrimitiveVector;
 import tech.pegasys.teku.ssz.backing.containers.Container2;
 import tech.pegasys.teku.ssz.backing.containers.ContainerSchema2;
 import tech.pegasys.teku.ssz.backing.schema.SszPrimitiveSchemas;
 import tech.pegasys.teku.ssz.backing.schema.SszVectorSchema;
+import tech.pegasys.teku.ssz.backing.schema.collections.SszPrimitiveVectorSchema;
 import tech.pegasys.teku.ssz.backing.tree.TreeNode;
 import tech.pegasys.teku.ssz.backing.view.AbstractSszPrimitive;
 import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszBytes32;
@@ -52,13 +54,14 @@ public class HistoricalBatch
       return new HistoricalBatch(this, node);
     }
 
-    public HistoricalBatch create(SSZVector<Bytes32> block_roots, SSZVector<Bytes32> state_roots) {
+    public HistoricalBatch create(
+        SszPrimitiveVector<Bytes32, SszBytes32> block_roots, SSZVector<Bytes32> state_roots) {
       return new HistoricalBatch(this, block_roots, state_roots);
     }
 
     @SuppressWarnings("unchecked")
-    public SszVectorSchema<SszBytes32, ?> getBlockRootsSchema() {
-      return (SszVectorSchema<SszBytes32, ?>) getFieldSchema0();
+    public SszPrimitiveVectorSchema<Bytes32, SszBytes32, ?> getBlockRootsSchema() {
+      return (SszPrimitiveVectorSchema<Bytes32, SszBytes32, ?>) getFieldSchema0();
     }
 
     @SuppressWarnings("unchecked")
@@ -79,15 +82,18 @@ public class HistoricalBatch
   }
 
   @Deprecated // Use the constructor with type
-  public HistoricalBatch(SSZVector<Bytes32> block_roots, SSZVector<Bytes32> state_roots) {
+  public HistoricalBatch(
+      SszPrimitiveVector<Bytes32, SszBytes32> block_roots, SSZVector<Bytes32> state_roots) {
     this(SSZ_SCHEMA.get(), block_roots, state_roots);
   }
 
   private HistoricalBatch(
-      HistoricalBatchSchema type, SSZVector<Bytes32> block_roots, SSZVector<Bytes32> state_roots) {
+      HistoricalBatchSchema type,
+      SszPrimitiveVector<Bytes32, SszBytes32> block_roots,
+      SSZVector<Bytes32> state_roots) {
     super(
         type,
-        SszUtils.toSszVector(type.getBlockRootsSchema(), block_roots, SszBytes32::new),
+        block_roots,
         SszUtils.toSszVector(type.getStateRootsSchema(), state_roots, SszBytes32::new));
   }
 

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/MutableBeaconState.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/MutableBeaconState.java
@@ -26,6 +26,8 @@ import tech.pegasys.teku.ssz.backing.SszList;
 import tech.pegasys.teku.ssz.backing.SszMutableList;
 import tech.pegasys.teku.ssz.backing.SszMutableRefContainer;
 import tech.pegasys.teku.ssz.backing.collections.SszBitvector;
+import tech.pegasys.teku.ssz.backing.collections.SszMutablePrimitiveVector;
+import tech.pegasys.teku.ssz.backing.collections.SszPrimitiveVector;
 import tech.pegasys.teku.ssz.backing.view.AbstractSszPrimitive;
 import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszBytes32;
 import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszUInt64;
@@ -60,9 +62,12 @@ public interface MutableBeaconState extends BeaconState, SszMutableRefContainer 
   }
 
   @Override
-  default SSZMutableVector<Bytes32> getBlock_roots() {
-    return new SSZBackingVector<>(
-        Bytes32.class, getAnyByRef(5), SszBytes32::new, AbstractSszPrimitive::get);
+  default SszMutablePrimitiveVector<Bytes32, SszBytes32> getBlock_roots() {
+    return getAnyByRef(5);
+  }
+
+  default void setBlock_roots(SszPrimitiveVector<Bytes32, SszBytes32> block_roots) {
+    set(BLOCK_ROOTS_FIELD.getIndex(), block_roots);
   }
 
   @Override

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/MutableBeaconStateImpl.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/state/MutableBeaconStateImpl.java
@@ -33,7 +33,6 @@ class MutableBeaconStateImpl extends SszMutableContainerImpl
   private final boolean builder;
 
   private SSZMutableList<UInt64> balances;
-  private SSZMutableVector<Bytes32> blockRoots;
   private SSZMutableVector<Bytes32> stateRoots;
   private SSZMutableList<Bytes32> historicalRoots;
   private SSZMutableVector<Bytes32> randaoMixes;
@@ -84,13 +83,6 @@ class MutableBeaconStateImpl extends SszMutableContainerImpl
   @Override
   public SSZMutableList<UInt64> getBalances() {
     return balances != null ? balances : (balances = MutableBeaconState.super.getBalances());
-  }
-
-  @Override
-  public SSZMutableVector<Bytes32> getBlock_roots() {
-    return blockRoots != null
-        ? blockRoots
-        : (blockRoots = MutableBeaconState.super.getBlock_roots());
   }
 
   @Override

--- a/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
+++ b/ethereum/datastructures/src/main/java/tech/pegasys/teku/datastructures/util/BeaconStateUtil.java
@@ -873,7 +873,7 @@ public class BeaconStateUtil {
         slot,
         state.getSlot());
     int latestBlockRootIndex = slot.mod(SLOTS_PER_HISTORICAL_ROOT).intValue();
-    return state.getBlock_roots().get(latestBlockRootIndex);
+    return state.getBlock_roots().getElement(latestBlockRootIndex);
   }
 
   @Deprecated

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/BeaconStateTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/BeaconStateTest.java
@@ -89,7 +89,7 @@ class BeaconStateTest {
       // this call should reset all the memorized spec constants
       BeaconState s2 = BeaconState.createEmpty();
 
-      assertThat(s1.getBlock_roots().getMaxSize()).isNotEqualTo(s2.getBlock_roots().getMaxSize());
+      assertThat(s1.getBlock_roots().size()).isNotEqualTo(s2.getBlock_roots().size());
       assertThat(s1.getState_roots().getMaxSize()).isNotEqualTo(s2.getState_roots().getMaxSize());
       assertThat(s1.getHistorical_roots().getMaxSize())
           .isNotEqualTo(s2.getHistorical_roots().getMaxSize());

--- a/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/HistoricalBatchTest.java
+++ b/ethereum/datastructures/src/test/java/tech/pegasys/teku/datastructures/state/HistoricalBatchTest.java
@@ -28,6 +28,8 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.ssz.SSZTypes.SSZMutableVector;
 import tech.pegasys.teku.ssz.SSZTypes.SSZVector;
 import tech.pegasys.teku.ssz.backing.SszTestUtils;
+import tech.pegasys.teku.ssz.backing.collections.SszMutablePrimitiveVector;
+import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszBytes32;
 import tech.pegasys.teku.util.config.Constants;
 import tech.pegasys.teku.util.config.SpecDependent;
 
@@ -56,14 +58,15 @@ public class HistoricalBatchTest {
 
   @Test
   void roundTripViaSsz() {
-    SSZMutableVector<Bytes32> block_roots =
-        SSZVector.createMutable(Constants.SLOTS_PER_HISTORICAL_ROOT, Bytes32.ZERO);
+
+    SszMutablePrimitiveVector<Bytes32, SszBytes32> block_roots =
+        HistoricalBatch.SSZ_SCHEMA.get().getBlockRootsSchema().getDefault().createWritableCopy();
     SSZMutableVector<Bytes32> state_roots =
         SSZVector.createMutable(Constants.SLOTS_PER_HISTORICAL_ROOT, Bytes32.ZERO);
     IntStream.range(0, Constants.SLOTS_PER_HISTORICAL_ROOT)
         .forEach(
             i -> {
-              block_roots.set(i, dataStructureUtil.randomBytes32());
+              block_roots.setElement(i, dataStructureUtil.randomBytes32());
               state_roots.set(i, dataStructureUtil.randomBytes32());
             });
     HistoricalBatch batch = new HistoricalBatch(block_roots, state_roots);

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/util/BeaconStateUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/util/BeaconStateUtil.java
@@ -127,7 +127,7 @@ public class BeaconStateUtil {
         slot,
         state.getSlot());
     int latestBlockRootIndex = slot.mod(specConstants.getSlotsPerHistoricalRoot()).intValue();
-    return state.getBlock_roots().get(latestBlockRootIndex);
+    return state.getBlock_roots().getElement(latestBlockRootIndex);
   }
 
   public Bytes32 getBlockRoot(BeaconState state, UInt64 epoch) throws IllegalArgumentException {

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilder.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/util/BeaconStateBuilder.java
@@ -28,6 +28,8 @@ import tech.pegasys.teku.ssz.SSZTypes.SSZList;
 import tech.pegasys.teku.ssz.SSZTypes.SSZVector;
 import tech.pegasys.teku.ssz.backing.SszList;
 import tech.pegasys.teku.ssz.backing.collections.SszBitvector;
+import tech.pegasys.teku.ssz.backing.collections.SszPrimitiveVector;
+import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszBytes32;
 
 public class BeaconStateBuilder {
   private final DataStructureUtil dataStructureUtil;
@@ -39,7 +41,7 @@ public class BeaconStateBuilder {
   private UInt64 slot;
   private Fork fork;
   private BeaconBlockHeader latestBlockHeader;
-  private SSZVector<Bytes32> blockRoots;
+  private SszPrimitiveVector<Bytes32, SszBytes32> blockRoots;
   private SSZVector<Bytes32> stateRoots;
   private SSZList<Bytes32> historicalRoots;
   private Eth1Data eth1Data;
@@ -105,10 +107,8 @@ public class BeaconStateBuilder {
     fork = dataStructureUtil.randomFork();
     latestBlockHeader = dataStructureUtil.randomBeaconBlockHeader();
     blockRoots =
-        dataStructureUtil.randomSSZVector(
-            Bytes32.ZERO,
-            dataStructureUtil.getSlotsPerHistoricalRoot(),
-            dataStructureUtil::randomBytes32);
+        dataStructureUtil.randomSszVector(
+            BeaconState.BLOCK_ROOTS_FIELD_SCHEMA.get(), dataStructureUtil::randomBytes32);
     stateRoots =
         dataStructureUtil.randomSSZVector(
             Bytes32.ZERO,
@@ -202,7 +202,7 @@ public class BeaconStateBuilder {
     return this;
   }
 
-  public BeaconStateBuilder blockRoots(final SSZVector<Bytes32> blockRoots) {
+  public BeaconStateBuilder blockRoots(final SszPrimitiveVector<Bytes32, SszBytes32> blockRoots) {
     checkNotNull(blockRoots);
     this.blockRoots = blockRoots;
     return this;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollector.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/StateRootCollector.java
@@ -22,6 +22,8 @@ import tech.pegasys.teku.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.datastructures.state.BeaconState;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.ssz.SSZTypes.SSZVector;
+import tech.pegasys.teku.ssz.backing.collections.SszPrimitiveVector;
+import tech.pegasys.teku.ssz.backing.view.SszPrimitives.SszBytes32;
 import tech.pegasys.teku.storage.store.UpdatableStore.StoreTransaction;
 
 public class StateRootCollector {
@@ -30,12 +32,13 @@ public class StateRootCollector {
   public static void addParentStateRoots(
       final BeaconState blockSlotState, final StoreTransaction transaction) {
     final UInt64 newBlockSlot = blockSlotState.getSlot();
-    final SSZVector<Bytes32> blockRoots = blockSlotState.getBlock_roots();
+    final SszPrimitiveVector<Bytes32, SszBytes32> blockRoots = blockSlotState.getBlock_roots();
     final SSZVector<Bytes32> stateRoots = blockSlotState.getState_roots();
     final UInt64 minimumSlot = newBlockSlot.minusMinZero(SLOTS_PER_HISTORICAL_ROOT);
     // Get the parent block root from the state as the genesis block root is recorded as 0
     final Bytes32 parentBlockRoot =
-        blockRoots.get(newBlockSlot.minusMinZero(1).mod(SLOTS_PER_HISTORICAL_ROOT).intValue());
+        blockRoots.getElement(
+            newBlockSlot.minusMinZero(1).mod(SLOTS_PER_HISTORICAL_ROOT).intValue());
     UInt64 slot = newBlockSlot.minusMinZero(1);
     while (slot.isGreaterThanOrEqualTo(minimumSlot) && !slot.isZero()) {
       final Bytes32 previousBlockRoot = getValue(blockRoots, slot.minus(1));
@@ -50,6 +53,11 @@ public class StateRootCollector {
     if (!slot.isZero()) {
       LOG.warn("Missing some state root mappings prior to slot {}", minimumSlot);
     }
+  }
+
+  private static Bytes32 getValue(
+      final SszPrimitiveVector<Bytes32, SszBytes32> roots, final UInt64 slot) {
+    return roots.getElement(slot.mod(SLOTS_PER_HISTORICAL_ROOT).intValue());
   }
 
   private static Bytes32 getValue(final SSZVector<Bytes32> roots, final UInt64 slot) {

--- a/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
+++ b/services/beaconchain/src/test/java/tech/pegasys/teku/services/beaconchain/BeaconChainMetricsTest.java
@@ -46,7 +46,6 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.ssz.SSZTypes.SSZList;
-import tech.pegasys.teku.ssz.SSZTypes.SSZVector;
 import tech.pegasys.teku.ssz.backing.collections.SszBitlist;
 import tech.pegasys.teku.ssz.backing.schema.SszListSchema;
 import tech.pegasys.teku.storage.client.MemoryOnlyRecentChainData;
@@ -88,8 +87,8 @@ class BeaconChainMetricsTest {
     when(state.getPrevious_justified_checkpoint()).thenReturn(previousJustifiedCheckpoint);
     List<Bytes32> blockRootsList =
         new ArrayList<>(Collections.nCopies(1000, dataStructureUtil.randomBytes32()));
-    SSZVector<Bytes32> blockRootSSZList = SSZVector.createMutable(blockRootsList, Bytes32.class);
-    when(state.getBlock_roots()).thenReturn(blockRootSSZList);
+    when(state.getBlock_roots())
+        .thenReturn(BeaconState.BLOCK_ROOTS_FIELD_SCHEMA.get().of(blockRootsList));
   }
 
   @Test
@@ -351,8 +350,8 @@ class BeaconChainMetricsTest {
         new ArrayList<>(Collections.nCopies(33, dataStructureUtil.randomBytes32()));
     blockRootsList.set(
         target.getEpochStartSlot().mod(SLOTS_PER_HISTORICAL_ROOT).intValue(), blockRoot);
-    SSZVector<Bytes32> blockRootSSZList = SSZVector.createMutable(blockRootsList, Bytes32.class);
-    when(state.getBlock_roots()).thenReturn(blockRootSSZList);
+    when(state.getBlock_roots())
+        .thenReturn(BeaconState.BLOCK_ROOTS_FIELD_SCHEMA.get().of(blockRootsList));
     final SszBitlist bitlist1 = bitlistOf(1, 3, 5, 7);
     final SszBitlist bitlist2 = bitlistOf(2, 4, 6, 8);
     List<PendingAttestation> allAttestations =
@@ -382,8 +381,8 @@ class BeaconChainMetricsTest {
     List<Bytes32> blockRootsList =
         new ArrayList<>(Collections.nCopies(33, dataStructureUtil.randomBytes32()));
     blockRootsList.set(slot.mod(SLOTS_PER_HISTORICAL_ROOT).intValue(), blockRoot);
-    SSZVector<Bytes32> blockRootSSZList = SSZVector.createMutable(blockRootsList, Bytes32.class);
-    when(state.getBlock_roots()).thenReturn(blockRootSSZList);
+    when(state.getBlock_roots())
+        .thenReturn(BeaconState.BLOCK_ROOTS_FIELD_SCHEMA.get().of(blockRootsList));
     final SszBitlist bitlist1 = bitlistOf(1, 3, 5, 7);
     final SszBitlist bitlist2 = bitlistOf(2, 4, 6, 8);
     List<PendingAttestation> allAttestations =
@@ -412,8 +411,8 @@ class BeaconChainMetricsTest {
         new ArrayList<>(Collections.nCopies(33, dataStructureUtil.randomBytes32()));
     final int blockRootIndex = target.getEpochStartSlot().mod(SLOTS_PER_HISTORICAL_ROOT).intValue();
     blockRootsList.set(blockRootIndex, blockRoot);
-    SSZVector<Bytes32> blockRootSSZList = SSZVector.createMutable(blockRootsList, Bytes32.class);
-    when(state.getBlock_roots()).thenReturn(blockRootSSZList);
+    when(state.getBlock_roots())
+        .thenReturn(BeaconState.BLOCK_ROOTS_FIELD_SCHEMA.get().of(blockRootsList));
     final SszBitlist bitlist1 = bitlistOf(1, 3, 5, 7);
     final SszBitlist bitlist2 = bitlistOf(2, 4, 6, 8);
     List<PendingAttestation> allAttestations =

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/backing/collections/SszMutablePrimitiveList.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/backing/collections/SszMutablePrimitiveList.java
@@ -24,5 +24,8 @@ public interface SszMutablePrimitiveList<
   SszPrimitiveList<ElementT, SszElementT> commitChanges();
 
   @Override
-  SszMutablePrimitiveList<ElementT, SszElementT> createWritableCopy();
+  default SszMutablePrimitiveList<ElementT, SszElementT> createWritableCopy() {
+    throw new UnsupportedOperationException(
+        "Creating a writable copy from writable instance is not supported");
+  }
 }

--- a/ssz/src/main/java/tech/pegasys/teku/ssz/backing/schema/collections/SszPrimitiveCollectionSchema.java
+++ b/ssz/src/main/java/tech/pegasys/teku/ssz/backing/schema/collections/SszPrimitiveCollectionSchema.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.ssz.backing.schema.collections;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.ssz.backing.SszPrimitive;
 import tech.pegasys.teku.ssz.backing.collections.SszPrimitiveCollection;
@@ -41,5 +42,9 @@ public interface SszPrimitiveCollectionSchema<
   @SuppressWarnings("unchecked")
   default SszPrimitiveSchema<ElementT, SszElementT> getPrimitiveElementSchema() {
     return (SszPrimitiveSchema<ElementT, SszElementT>) getElementSchema();
+  }
+
+  default Collector<ElementT, ?, SszCollectionT> collectorUnboxed() {
+    return Collectors.collectingAndThen(Collectors.<ElementT>toList(), this::of);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/PegaSysEng/teku/blob/master/CONTRIBUTING.md -->

## PR Description

This is kind of temp sub-PR to discuss how primitive SSZ collections would be better to expose. 

For example this PR variant looks for former `SSZVector<Bytes32>` like
```java
SszPrimitiveVector<Bytes32, SszBytes32>
```
Slightly more verbose :/

Funny that the second `SszBytes32` type parameter implies the first `Bytes32` type parameter but there is no way to express it in Java so wherever you go you would need to specify both. 

The schema for this vector looks even more scary: 
```java
// compact 
SszPrimitiveVectorSchema<Bytes32, SszBytes32, ?>
// full
SszPrimitiveVectorSchema<Bytes32, SszBytes32, SszPrimitiveVector<Bytes32, SszBytes32>>
```

All that seems a bit overwhelming and complicated in usage 

## Alternatives

1. Create a set of classes for every primitive collection, e.g. `SszBytes32Vector`, `SszMutableUIntList`, `SszUIntVectorSchema` but this looks even more confusing from my perspective
2. Stick with the current `SSZList`-like wrappers, but it also confusing having different kinds of 'ssz strustures'. `SSZList` is not an `SszData` instance and that breaks the idea of SSZ structure hierarchy containing just `SszData` instances 
3. Leave wrapped primitive collections. I.e. `SszList<SszUInt64>` instead of current `SSZList<UInt64>`. They still could be backed up by optimized specific implementations though. The drawback of this solution is that you would always need to do manual boxing/unboxing 

I'd personally prefer the 3rd alternative. It seems a simplest approach for usage while would require a bit more boilerplate 

Note: `SszBitlist`, `SszBitvector` and `SszByteVector` are not discussed here as they kind of special types and would still have dedicated schemas and interfaces 

