### PR TITLE
Speedup block production (via Stream.parallel())

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
@@ -22,6 +22,8 @@ import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.IntStream;
+
+import it.unimi.dsi.fastutil.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.crypto.Hash;
@@ -75,7 +77,7 @@ public class BlobsUtil {
   }
 
   public List<KZGCommitment> blobsToKzgCommitments(final List<Blob> blobs) {
-    return blobs.stream().map(Blob::getBytes).map(kzg::blobToKzgCommitment).toList();
+    return blobs.stream().parallel().map(Blob::getBytes).map(kzg::blobToKzgCommitment).toList();
   }
 
   public KZGProof computeKzgProof(final Blob blob, final KZGCommitment kzgCommitment) {
@@ -84,7 +86,12 @@ public class BlobsUtil {
 
   public List<KZGProof> computeKzgProofs(
       final List<Blob> blobs, final List<KZGCommitment> kzgCommitments) {
-    return Streams.zip(blobs.stream(), kzgCommitments.stream(), this::computeKzgProof).toList();
+    return Streams.zip(blobs.stream(), kzgCommitments.stream(), Pair::of)
+        .parallel()
+        .map(
+            blobAndCommitment ->
+                computeKzgProof(blobAndCommitment.first(), blobAndCommitment.second()))
+        .toList();
   }
 
   public List<Blob> generateBlobs(final UInt64 slot, final int count) {

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/util/BlobsUtil.java
@@ -22,8 +22,7 @@ import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.IntStream;
-
-import it.unimi.dsi.fastutil.Pair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.crypto.Hash;
@@ -90,7 +89,7 @@ public class BlobsUtil {
         .parallel()
         .map(
             blobAndCommitment ->
-                computeKzgProof(blobAndCommitment.first(), blobAndCommitment.second()))
+                computeKzgProof(blobAndCommitment.getLeft(), blobAndCommitment.getRight()))
         .toList();
   }
 

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip7594/helpers/MiscHelpersEip7594.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/versions/eip7594/helpers/MiscHelpersEip7594.java
@@ -168,7 +168,7 @@ public class MiscHelpersEip7594 extends MiscHelpersDeneb {
         dataColumnSidecarSchema.getKzgProofsSchema();
 
     List<List<KZGCellAndProof>> blobsCellsAndProofs =
-        blobs.stream().map(blob -> kzg.computeCellsAndProofs(blob.getBytes())).toList();
+        blobs.stream().parallel().map(blob -> kzg.computeCellsAndProofs(blob.getBytes())).toList();
 
     int columnCount = blobsCellsAndProofs.get(0).size();
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Speedup block production (in stub EL) and publishing by parallelizing heavy KZG calcs