### PR TITLE
Ref tests 1.5.0.alpha.2 + jc-kzg usage update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,7 +295,7 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v1.5.0-alpha.1' // Arbitrary change to refresh cache number: 1
+def refTestVersion = 'v1.5.0-alpha.2' // Arbitrary change to refresh cache number: 1
 def blsRefTestVersion = 'v0.1.2'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-spec-tests/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/kzg/KzgTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/kzg/KzgTestExecutor.java
@@ -16,7 +16,6 @@ package tech.pegasys.teku.reference.phase0.kzg;
 import static tech.pegasys.teku.ethtests.finder.KzgTestFinder.KZG_DATA_FILE;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import tech.pegasys.teku.ethtests.finder.TestDefinition;
@@ -28,21 +27,9 @@ import tech.pegasys.teku.reference.TestExecutor;
 public abstract class KzgTestExecutor implements TestExecutor {
 
   private static final Pattern TEST_NAME_PATTERN = Pattern.compile("kzg-(.+)/.+");
-  // TODO: update kzg and retest, should help
-  private static final List<String> IGNORED_TESTS =
-      List.of(
-          "verify_cell_kzg_proof_batch_case_valid_21b209cb4f64d0ed",
-          "verify_cell_kzg_proof_batch_case_valid_7dc4b00d04efff0c",
-          "verify_cell_kzg_proof_batch_case_valid_fad5448f3ceb0978",
-          "verify_cell_kzg_proof_batch_case_valid_unused_row_commitments_bc80af6ef27f8129");
 
   @Override
   public final void runTest(final TestDefinition testDefinition) throws Throwable {
-    final int lastSlash = testDefinition.getTestName().lastIndexOf("/");
-    final String testName = testDefinition.getTestName().substring(lastSlash + 1);
-    if (IGNORED_TESTS.contains(testName)) {
-      return;
-    }
     final String network = extractNetwork(testDefinition.getTestName());
     final KZG kzg = KzgRetriever.getKzgWithLoadedTrustedSetup(network);
     runTest(testDefinition, kzg);

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/CKZG4844.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/CKZG4844.java
@@ -158,7 +158,7 @@ final class CKZG4844 implements KZG {
 
   @Override
   public List<KZGCellAndProof> computeCellsAndProofs(Bytes blob) {
-    CellsAndProofs cellsAndProofs = CKZG4844JNI.computeCellsAndProofs(blob.toArrayUnsafe());
+    CellsAndProofs cellsAndProofs = CKZG4844JNI.computeCellsAndKzgProofs(blob.toArrayUnsafe());
     List<KZGCell> cells = KZGCell.splitBytes(Bytes.wrap(cellsAndProofs.getCells()));
     List<KZGProof> proofs = KZGProof.splitBytes(Bytes.wrap(cellsAndProofs.getProofs()));
     if (cells.size() != proofs.size()) {
@@ -172,7 +172,7 @@ final class CKZG4844 implements KZG {
   @Override
   public boolean verifyCellProof(
       KZGCommitment commitment, KZGCellWithColumnId cellWithColumnId, KZGProof proof) {
-    return CKZG4844JNI.verifyCellProof(
+    return CKZG4844JNI.verifyCellKzgProof(
         commitment.toArrayUnsafe(),
         cellWithColumnId.columnId().id().longValue(),
         cellWithColumnId.cell().bytes().toArrayUnsafe(),
@@ -184,7 +184,7 @@ final class CKZG4844 implements KZG {
       List<KZGCommitment> commitments,
       List<KZGCellWithIds> cellWithIdsList,
       List<KZGProof> proofs) {
-    return CKZG4844JNI.verifyCellProofBatch(
+    return CKZG4844JNI.verifyCellKzgProofBatch(
         CKZG4844Utils.flattenCommitments(commitments),
         cellWithIdsList.stream()
             .mapToLong(cellWithIds -> cellWithIds.rowId().id().longValue())
@@ -204,7 +204,7 @@ final class CKZG4844 implements KZG {
     byte[] cellBytes =
         CKZG4844Utils.flattenBytes(
             cells.stream().map(c -> c.cell().bytes()).toList(), cells.size() * BYTES_PER_CELL);
-    byte[] recovered = CKZG4844JNI.recoverCells(cellIds, cellBytes);
+    byte[] recovered = CKZG4844JNI.recoverAllCells(cellIds, cellBytes);
     return KZGCell.splitBytes(Bytes.wrap(recovered));
   }
 }

--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
+++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/KZG.java
@@ -13,7 +13,7 @@
 
 package tech.pegasys.teku.kzg;
 
-import static ethereum.ckzg4844.CKZG4844JNI.CELLS_PER_BLOB;
+import static ethereum.ckzg4844.CKZG4844JNI.CELLS_PER_EXT_BLOB;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -97,10 +97,10 @@ public interface KZG {
 
         @Override
         public List<KZGCell> recoverCells(List<KZGCellWithColumnId> cells) {
-          if (cells.size() < CELLS_PER_BLOB) {
+          if (cells.size() < CELLS_PER_EXT_BLOB) {
             throw new IllegalArgumentException("Can't recover from " + cells.size() + " cells");
           }
-          return cells.stream().map(KZGCellWithColumnId::cell).limit(CELLS_PER_BLOB).toList();
+          return cells.stream().map(KZGCellWithColumnId::cell).limit(CELLS_PER_EXT_BLOB).toList();
         }
       };
 

--- a/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/CKZG4844Test.java
+++ b/infrastructure/kzg/src/test/java/tech/pegasys/teku/kzg/CKZG4844Test.java
@@ -15,7 +15,7 @@ package tech.pegasys.teku.kzg;
 
 import static ethereum.ckzg4844.CKZG4844JNI.BLS_MODULUS;
 import static ethereum.ckzg4844.CKZG4844JNI.BYTES_PER_BLOB;
-import static ethereum.ckzg4844.CKZG4844JNI.CELLS_PER_BLOB;
+import static ethereum.ckzg4844.CKZG4844JNI.CELLS_PER_EXT_BLOB;
 import static ethereum.ckzg4844.CKZG4844JNI.FIELD_ELEMENTS_PER_BLOB;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -283,7 +283,6 @@ public final class CKZG4844Test {
         .hasMessage("Expected G2 point to be 96 bytes");
   }
 
-  static final int CELLS_PER_EXT_BLOB = CELLS_PER_BLOB;
   static final int CELLS_PER_ORIG_BLOB = CELLS_PER_EXT_BLOB / 2;
 
   @Test


### PR DESCRIPTION
- Updating jc-kzg really solved segmentation faults in number of batch proof verification tests, so ignore block is removed.
- JNI was changed a little, updated usage.
- No new issues with today release of the tests, we pass now really everything.