### PR TITLE
Track extra subnet count by gossip subscriptions 

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -31,19 +31,20 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
 
 public class DataColumnSidecarCustodyImpl
     implements UpdatableDataColumnSidecarCustody, SlotEventsChannel {
 
-  public interface DataColumnBlockRootResolver {
+  public interface CanonicalBlockResolver {
 
     /**
      * Should return the canonical block root at slot if: - a block exist at this slot - block
      * contains any blobs
      */
-    Optional<Bytes32> getColumnBlockRootAtSlot(UInt64 slot);
+    Optional<BeaconBlock> getBlockAtSlot(UInt64 slot);
   }
 
   private record SlotCustody(
@@ -82,7 +83,7 @@ public class DataColumnSidecarCustodyImpl
 
   private final Spec spec;
   private final DataColumnSidecarDB db;
-  private final DataColumnBlockRootResolver blockRootResolver;
+  private final CanonicalBlockResolver blockResolver;
   private final UInt256 nodeId;
   private final int totalCustodySubnetCount;
 
@@ -92,19 +93,19 @@ public class DataColumnSidecarCustodyImpl
 
   public DataColumnSidecarCustodyImpl(
       Spec spec,
-      DataColumnBlockRootResolver blockRootResolver,
+      CanonicalBlockResolver blockResolver,
       DataColumnSidecarDB db,
       UInt256 nodeId,
       int totalCustodySubnetCount) {
 
     checkNotNull(spec);
-    checkNotNull(blockRootResolver);
+    checkNotNull(blockResolver);
     checkNotNull(db);
     checkNotNull(nodeId);
 
     this.spec = spec;
     this.db = db;
-    this.blockRootResolver = blockRootResolver;
+    this.blockResolver = blockResolver;
     this.nodeId = nodeId;
     this.totalCustodySubnetCount = totalCustodySubnetCount;
     this.eip7594StartEpoch = spec.getForkSchedule().getFork(SpecMilestone.EIP7594).getEpoch();
@@ -219,14 +220,27 @@ public class DataColumnSidecarCustodyImpl
             firstIncompleteSlot, slot -> slot.isLessThanOrEqualTo(currentSlot), UInt64::increment)
         .map(
             slot -> {
-              Optional<Bytes32> maybeCanonicalBlockRoot =
-                  blockRootResolver.getColumnBlockRootAtSlot(slot);
+              Optional<Bytes32> maybeCanonicalBlockRoot = getBlockRootIfHaveBlobs(slot);
               List<UInt64> requiredColumns = getCustodyColumnsForSlot(slot);
               List<DataColumnIdentifier> existingColumns =
                   db.streamColumnIdentifiers(slot).toList();
               return new SlotCustody(
                   slot, maybeCanonicalBlockRoot, requiredColumns, existingColumns);
             });
+  }
+
+  private Optional<Bytes32> getBlockRootIfHaveBlobs(UInt64 slot) {
+                 return blockResolver   .getBlockAtSlot(slot)
+                    .filter(
+                        block ->
+                            block
+                                .getBeaconBlock()
+                                .flatMap(b -> b.getBody().toVersionEip7594())
+                                .map(b -> b.getBlobKzgCommitments().size())
+                                .orElse(0)
+                                > 0)
+                    .map(BeaconBlock::getRoot);
+
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -230,17 +230,17 @@ public class DataColumnSidecarCustodyImpl
   }
 
   private Optional<Bytes32> getBlockRootIfHaveBlobs(UInt64 slot) {
-                 return blockResolver   .getBlockAtSlot(slot)
-                    .filter(
-                        block ->
-                            block
-                                .getBeaconBlock()
-                                .flatMap(b -> b.getBody().toVersionEip7594())
-                                .map(b -> b.getBlobKzgCommitments().size())
-                                .orElse(0)
-                                > 0)
-                    .map(BeaconBlock::getRoot);
-
+    return blockResolver
+        .getBlockAtSlot(slot)
+        .filter(
+            block ->
+                block
+                        .getBeaconBlock()
+                        .flatMap(b -> b.getBody().toVersionEip7594())
+                        .map(b -> b.getBlobKzgCommitments().size())
+                        .orElse(0)
+                    > 0)
+        .map(BeaconBlock::getRoot);
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DasPeerCustodyCountSupplier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DasPeerCustodyCountSupplier.java
@@ -15,10 +15,18 @@ package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
 import org.apache.tuweni.units.bigints.UInt256;
 
+import static java.lang.Integer.max;
+import static java.lang.Integer.min;
+
 public interface DasPeerCustodyCountSupplier {
 
   static DasPeerCustodyCountSupplier createStub(int defaultValue) {
     return (__) -> defaultValue;
+  }
+
+  static DasPeerCustodyCountSupplier capped(DasPeerCustodyCountSupplier delegate, int minValue, int maxValue) {
+    return (nodeId) ->
+        min(maxValue, max(minValue, delegate.getCustodyCountForPeer(nodeId)));
   }
 
   int getCustodyCountForPeer(UInt256 nodeId);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DasPeerCustodyCountSupplier.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DasPeerCustodyCountSupplier.java
@@ -13,10 +13,10 @@
 
 package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
-import org.apache.tuweni.units.bigints.UInt256;
-
 import static java.lang.Integer.max;
 import static java.lang.Integer.min;
+
+import org.apache.tuweni.units.bigints.UInt256;
 
 public interface DasPeerCustodyCountSupplier {
 
@@ -24,9 +24,9 @@ public interface DasPeerCustodyCountSupplier {
     return (__) -> defaultValue;
   }
 
-  static DasPeerCustodyCountSupplier capped(DasPeerCustodyCountSupplier delegate, int minValue, int maxValue) {
-    return (nodeId) ->
-        min(maxValue, max(minValue, delegate.getCustodyCountForPeer(nodeId)));
+  static DasPeerCustodyCountSupplier capped(
+      DasPeerCustodyCountSupplier delegate, int minValue, int maxValue) {
+    return (nodeId) -> min(maxValue, max(minValue, delegate.getCustodyCountForPeer(nodeId)));
   }
 
   int getCustodyCountForPeer(UInt256 nodeId);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetBackboneSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetBackboneSubscriber.java
@@ -64,19 +64,22 @@ public class DataColumnSidecarSubnetBackboneSubscriber implements SlotEventsChan
     currentSubscribedSubnets = newSubscriptionsSet;
   }
 
+  private int getTotalSubnetCount(final UInt64 epoch) {
+    SpecConfigEip7594 configEip7594 = SpecConfigEip7594.required(spec.atEpoch(epoch).getConfig());
+    return Integer.min(
+        configEip7594.getDataColumnSidecarSubnetCount(),
+        configEip7594.getCustodyRequirement() + extraVoluntarySubnetCount);
+  }
+
   private void onEpoch(final UInt64 epoch) {
-    SpecVersion specVersion = spec.atEpoch(epoch);
-    specVersion
+    spec.atEpoch(epoch)
         .miscHelpers()
         .toVersionEip7594()
         .ifPresent(
             eip7594Spec -> {
-              int totalSubnetCount =
-                  SpecConfigEip7594.required(specVersion.getConfig()).getCustodyRequirement()
-                      + extraVoluntarySubnetCount;
               List<UInt64> subnets =
                   eip7594Spec.computeDataColumnSidecarBackboneSubnets(
-                      nodeId, epoch, totalSubnetCount);
+                      nodeId, epoch, getTotalSubnetCount(epoch));
               subscribeToSubnets(subnets.stream().map(UInt64::intValue).toList());
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetBackboneSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetBackboneSubscriber.java
@@ -22,7 +22,6 @@ import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.config.SpecConfigEip7594;
 
 public class DataColumnSidecarSubnetBackboneSubscriber implements SlotEventsChannel {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/GossipTopics.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/GossipTopics.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.spec.Spec;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/GossipTopics.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/topics/GossipTopics.java
@@ -13,8 +13,12 @@
 
 package tech.pegasys.teku.networking.eth2.gossip.topics;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import tech.pegasys.teku.infrastructure.bytes.Bytes4;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.spec.Spec;
@@ -69,6 +73,18 @@ public class GossipTopics {
         forkDigest, GossipTopicName.getDataColumnSidecarSubnetTopicName(subnetId), gossipEncoding);
   }
 
+  public static Set<String> getAllDataColumnSidecarSubnetTopics(
+      final GossipEncoding gossipEncoding, final Bytes4 forkDigest, final Spec spec) {
+
+    return spec.getNetworkingConfigEip7594()
+        .map(
+            eip7594NetworkConfig ->
+                IntStream.range(0, eip7594NetworkConfig.getDataColumnSidecarSubnetCount())
+                    .mapToObj(i -> getDataColumnSidecarSubnetTopic(forkDigest, i, gossipEncoding))
+                    .collect(Collectors.toSet()))
+        .orElse(Collections.emptySet());
+  }
+
   public static Set<String> getAllTopics(
       final GossipEncoding gossipEncoding, final Bytes4 forkDigest, final Spec spec) {
     final Set<String> topics = new HashSet<>();
@@ -84,13 +100,9 @@ public class GossipTopics {
         topics.add(getBlobSidecarSubnetTopic(forkDigest, i, gossipEncoding));
       }
     }
-    spec.getNetworkingConfigEip7594()
-        .ifPresent(
-            eip7594NetworkConfig -> {
-              for (int i = 0; i < eip7594NetworkConfig.getDataColumnSidecarSubnetCount(); i++) {
-                topics.add(getDataColumnSidecarSubnetTopic(forkDigest, i, gossipEncoding));
-              }
-            });
+
+    topics.addAll(getAllDataColumnSidecarSubnetTopics(gossipEncoding, forkDigest, spec));
+
     for (GossipTopicName topicName : GossipTopicName.values()) {
       topics.add(GossipTopics.getTopic(forkDigest, topicName, gossipEncoding));
     }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/GossipTopicDasPeerCustodyTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/GossipTopicDasPeerCustodyTracker.java
@@ -72,9 +72,7 @@ public class GossipTopicDasPeerCustodyTracker
         .map(
             forkInfo ->
                 GossipTopics.getAllDataColumnSidecarSubnetTopics(
-                    gossipEncoding,
-                    forkInfo.getForkDigest(spec),
-                    spec))
+                    gossipEncoding, forkInfo.getForkDigest(spec), spec))
         .orElse(Collections.emptySet());
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/GossipTopicDasPeerCustodyTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/GossipTopicDasPeerCustodyTracker.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.networking.eth2.peers;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
+import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopics;
+import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
+import tech.pegasys.teku.networking.p2p.peer.NodeId;
+import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.datastructures.state.ForkInfo;
+import tech.pegasys.teku.statetransition.datacolumns.retriever.DasPeerCustodyCountSupplier;
+
+public class GossipTopicDasPeerCustodyTracker
+    implements DasPeerCustodyCountSupplier, PeerConnectedSubscriber<Eth2Peer> {
+
+  public static final int NO_SUBNET_COUNT_INFO = -1;
+
+  private final Spec spec;
+  private final GossipNetwork gossipNetwork;
+  private final GossipEncoding gossipEncoding;
+  private final Supplier<Optional<ForkInfo>> currentForkInfoSupplier;
+
+  private final Map<UInt256, Entry> connectedPeerExtraSubnets = new ConcurrentHashMap<>();
+
+  public GossipTopicDasPeerCustodyTracker(
+      Spec spec,
+      GossipNetwork gossipNetwork,
+      GossipEncoding gossipEncoding,
+      Supplier<Optional<ForkInfo>> currentForkInfoSupplier) {
+    this.spec = spec;
+    this.gossipNetwork = gossipNetwork;
+    this.gossipEncoding = gossipEncoding;
+    this.currentForkInfoSupplier = currentForkInfoSupplier;
+  }
+
+  @Override
+  public void onConnected(Eth2Peer peer) {
+    connectedPeerExtraSubnets.put(
+        peer.getDiscoveryNodeId(), new Entry(peer.getId(), NO_SUBNET_COUNT_INFO));
+    peer.subscribeDisconnect((__, ___) -> peerDisconnected(peer));
+    refreshExistingSubscriptions();
+  }
+
+  private void peerDisconnected(Eth2Peer peer) {
+    connectedPeerExtraSubnets.remove(peer.getDiscoveryNodeId());
+  }
+
+  private Set<String> getCurrentDasTopics() {
+    return currentForkInfoSupplier
+        .get()
+        .map(
+            forkInfo ->
+                GossipTopics.getAllDataColumnSidecarSubnetTopics(
+                    gossipEncoding,
+                    forkInfo.getForkDigest(spec),
+                    spec))
+        .orElse(Collections.emptySet());
+  }
+
+  private void refreshExistingSubscriptions() {
+    Map<String, Collection<NodeId>> subscribersByTopic = gossipNetwork.getSubscribersByTopic();
+    Set<String> dasTopics = getCurrentDasTopics();
+    record NodeTopic(NodeId nodeId, String topic) {}
+
+    Map<NodeId, Long> nodeToSubnetCount =
+        subscribersByTopic.entrySet().stream()
+            .flatMap(
+                entry ->
+                    entry.getValue().stream().map(nodeId -> new NodeTopic(nodeId, entry.getKey())))
+            .filter(entry -> dasTopics.contains(entry.topic()))
+            .collect(Collectors.groupingBy(NodeTopic::nodeId, Collectors.counting()));
+    connectedPeerExtraSubnets.replaceAll(
+        (nodeId, entry) -> {
+          Long maybeCount = nodeToSubnetCount.get(entry.libp2pPeerId());
+          int count = maybeCount == null ? NO_SUBNET_COUNT_INFO : maybeCount.intValue();
+          return entry.withSubnetCount(count);
+        });
+  }
+
+  @Override
+  public int getCustodyCountForPeer(UInt256 nodeId) {
+    Entry entry = connectedPeerExtraSubnets.get(nodeId);
+    return entry != null ? entry.subnetCount() : 0;
+  }
+
+  private record Entry(NodeId libp2pPeerId, Integer subnetCount) {
+    public Entry withSubnetCount(int newCount) {
+      return newCount == subnetCount ? this : new Entry(libp2pPeerId, newCount);
+    }
+  }
+}

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -628,22 +628,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
     DataColumnSidecarDBImpl sidecarDB =
         new DataColumnSidecarDBImpl(
             combinedChainDataClient, eventChannels.getPublisher(SidecarUpdateChannel.class));
-    DataColumnSidecarCustodyImpl.DataColumnBlockRootResolver blockRootResolver =
+    DataColumnSidecarCustodyImpl.CanonicalBlockResolver blockRootResolver =
         slot ->
             combinedChainDataClient
                 .getBlockAtSlotExact(slot)
-                .thenApply(
-                    maybeBlock ->
-                        maybeBlock
-                            .filter(
-                                block ->
-                                    block
-                                            .getBeaconBlock()
-                                            .flatMap(b -> b.getBody().toVersionEip7594())
-                                            .map(b -> b.getBlobKzgCommitments().size())
-                                            .orElse(0)
-                                        > 0)
-                            .map(SignedBeaconBlock::getRoot))
+                .thenApply(sbb -> sbb.flatMap(SignedBeaconBlock::getBeaconBlock))
                 .join();
 
     int dasExtraCustodySubnetCount = beaconConfig.p2pConfig().getDasExtraCustodySubnetCount();

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -638,14 +638,14 @@ public class BeaconChainController extends Service implements BeaconChainControl
     int dasExtraCustodySubnetCount = beaconConfig.p2pConfig().getDasExtraCustodySubnetCount();
     SpecConfigEip7594 configEip7594 =
         SpecConfigEip7594.required(spec.forMilestone(SpecMilestone.EIP7594).getConfig());
-    int custodyRequirement = configEip7594.getCustodyRequirement();
+    int minCustodyRequirement = configEip7594.getCustodyRequirement();
     int maxSubnets = configEip7594.getDataColumnSidecarSubnetCount();
-    int totalCustodySubnets =
-        Integer.min(maxSubnets, custodyRequirement + dasExtraCustodySubnetCount);
+    int totalMyCustodySubnets =
+        Integer.min(maxSubnets, minCustodyRequirement + dasExtraCustodySubnetCount);
 
     DataColumnSidecarCustodyImpl dataColumnSidecarCustodyImpl =
         new DataColumnSidecarCustodyImpl(
-            spec, blockRootResolver, sidecarDB, nodeId, totalCustodySubnets);
+            spec, blockRootResolver, sidecarDB, nodeId, totalMyCustodySubnets);
     eventChannels.subscribe(SlotEventsChannel.class, dataColumnSidecarCustodyImpl);
     dataColumnSidecarManager.subscribeToValidDataColumnSidecars(
         dataColumnSidecarCustodyImpl::onNewValidatedDataColumnSidecar);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Implement `GossipTopicDasPeerCustodyTracker`
- Refactor `DataColumnBlockRootResolver` to move more logic from `BeaconChainController` to `DataColumnSidecarCustodyImpl`
- Fix the case when `extra_column_subnets` is too large