### PR TITLE
Fix remote subnet tracking, other stuff

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -166,9 +165,14 @@ public class SimpleSidecarRetriever
               match.peer);
     }
 
-    long activeRequestCount = pendingRequests.values().stream().filter(r -> r.activeRpcRequest != null).count();
-    LOG.info("[nyota] SimpleSidecarRetriever.nextRound: total pending: {}, active pending: {}, new pending: {}, number of custody peers: {}",
-            pendingRequests.size(), activeRequestCount, matches.size(), gatherAvailableCustodiesInfo());
+    long activeRequestCount =
+        pendingRequests.values().stream().filter(r -> r.activeRpcRequest != null).count();
+    LOG.info(
+        "[nyota] SimpleSidecarRetriever.nextRound: total pending: {}, active pending: {}, new pending: {}, number of custody peers: {}",
+        pendingRequests.size(),
+        activeRequestCount,
+        matches.size(),
+        gatherAvailableCustodiesInfo());
 
     reqResp.flush();
   }
@@ -189,15 +193,17 @@ public class SimpleSidecarRetriever
 
   private String gatherAvailableCustodiesInfo() {
     SpecVersion specVersion = spec.forMilestone(SpecMilestone.EIP7594);
-    Map<UInt64, Long> colIndexToCount = connectedPeers.values().stream()
+    Map<UInt64, Long> colIndexToCount =
+        connectedPeers.values().stream()
             .flatMap(p -> p.getNodeCustodyIndexes(specVersion).stream())
             .collect(Collectors.groupingBy(i -> i, Collectors.counting()));
     int numberOfColumns = SpecConfigEip7594.required(specVersion.getConfig()).getNumberOfColumns();
     IntStream.range(0, numberOfColumns)
-            .mapToObj(UInt64::valueOf)
-            .forEach(idx -> colIndexToCount.putIfAbsent(idx, 0L));
+        .mapToObj(UInt64::valueOf)
+        .forEach(idx -> colIndexToCount.putIfAbsent(idx, 0L));
     colIndexToCount.replaceAll((colIdx, count) -> Long.min(3, count));
-    Map<Long, Long> custodyCountToPeerCount = colIndexToCount.entrySet().stream()
+    Map<Long, Long> custodyCountToPeerCount =
+        colIndexToCount.entrySet().stream()
             .collect(Collectors.groupingBy(Map.Entry::getValue, Collectors.counting()));
     return new TreeMap<>(custodyCountToPeerCount)
         .entrySet().stream()
@@ -254,7 +260,8 @@ public class SimpleSidecarRetriever
     }
 
     public boolean isCustodyFor(ColumnSlotAndIdentifier columnId) {
-      return getNodeCustodyIndexes(spec.atSlot(columnId.slot())).contains(columnId.identifier().getIndex());
+      return getNodeCustodyIndexes(spec.atSlot(columnId.slot()))
+          .contains(columnId.identifier().getIndex());
     }
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
@@ -44,7 +44,6 @@ import tech.pegasys.teku.networking.p2p.peer.NodeId;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
-import tech.pegasys.teku.spec.config.SpecConfigEip7594;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.metadata.MetadataMessage;
 import tech.pegasys.teku.spec.datastructures.operations.AttesterSlashing;
 import tech.pegasys.teku.spec.datastructures.operations.ProposerSlashing;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
@@ -74,7 +74,7 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
   private final SubnetSubscriptionService dataColumnSidecarSubnetService;
   private final ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider;
   private final AtomicBoolean gossipStarted = new AtomicBoolean(false);
-  private final Optional<Integer> dasExtraCustodySubnetCount;
+  private final int dasExtraCustodySubnetCount;
 
   private final GossipForkManager gossipForkManager;
 
@@ -99,7 +99,7 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
       final GossipEncoding gossipEncoding,
       final GossipConfigurator gossipConfigurator,
       final ProcessedAttestationSubscriptionProvider processedAttestationSubscriptionProvider,
-      final Optional<Integer> dasExtraCustodySubnetCount,
+      final int dasExtraCustodySubnetCount,
       final boolean allTopicsFilterEnabled) {
     super(discoveryNetwork);
     this.spec = spec;
@@ -160,17 +160,9 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
         syncCommitteeSubnetService.subscribeToUpdates(
             discoveryNetwork::setSyncCommitteeSubnetSubscriptions);
     if (spec.isMilestoneSupported(SpecMilestone.EIP7594)) {
-      final int extraCustodySubnetCountConfig = dasExtraCustodySubnetCount.orElse(0);
-      final SpecConfigEip7594 configEip7594 =
-          SpecConfigEip7594.required(spec.forMilestone(SpecMilestone.EIP7594).getConfig());
-      final int minCustodyRequirement = configEip7594.getCustodyRequirement();
-      final int maxSubnets = configEip7594.getDataColumnSidecarSubnetCount();
-      final int extraCustodySubnetCount =
-          Integer.min(
-              Integer.max(0, maxSubnets - minCustodyRequirement), extraCustodySubnetCountConfig);
-      LOG.info("Using extra custody sidecar columns count: {}", extraCustodySubnetCount);
-      if (extraCustodySubnetCount != 0) {
-        discoveryNetwork.setDASExtraCustodySubnetCount(extraCustodySubnetCount);
+      LOG.info("Using extra custody sidecar columns count: {}", dasExtraCustodySubnetCount);
+      if (dasExtraCustodySubnetCount != 0) {
+        discoveryNetwork.setDASExtraCustodySubnetCount(dasExtraCustodySubnetCount);
       }
     }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -198,10 +198,6 @@ public class Eth2P2PNetworkBuilder {
     final GossipForkManager gossipForkManager = buildGossipForkManager(gossipEncoding, network);
 
     int dasExtraCustodySubnetCount = config.getDasExtraCustodySubnetCount(spec.forMilestone(SpecMilestone.EIP7594));
-    final Optional<Integer> dasExtraCustodySubnetCountOpt =
-            dasExtraCustodySubnetCount == 0
-            ? Optional.empty()
-            : Optional.of(dasExtraCustodySubnetCount);
 
     return new ActiveEth2P2PNetwork(
         config.getSpec(),
@@ -217,7 +213,7 @@ public class Eth2P2PNetworkBuilder {
         gossipEncoding,
         config.getGossipConfigurator(),
         processedAttestationSubscriptionProvider,
-        dasExtraCustodySubnetCountOpt,
+        dasExtraCustodySubnetCount,
         config.isAllTopicsFilterEnabled());
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -74,6 +74,7 @@ import tech.pegasys.teku.networking.p2p.reputation.DefaultReputationManager;
 import tech.pegasys.teku.networking.p2p.reputation.ReputationManager;
 import tech.pegasys.teku.networking.p2p.rpc.RpcMethod;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.config.Constants;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
@@ -196,10 +197,11 @@ public class Eth2P2PNetworkBuilder {
 
     final GossipForkManager gossipForkManager = buildGossipForkManager(gossipEncoding, network);
 
-    final Optional<Integer> dasExtraCustodySubnetCount =
-        config.getDasExtraCustodySubnetCount() == 0
+    int dasExtraCustodySubnetCount = config.getDasExtraCustodySubnetCount(spec.forMilestone(SpecMilestone.EIP7594));
+    final Optional<Integer> dasExtraCustodySubnetCountOpt =
+            dasExtraCustodySubnetCount == 0
             ? Optional.empty()
-            : Optional.of(config.getDasExtraCustodySubnetCount());
+            : Optional.of(dasExtraCustodySubnetCount);
 
     return new ActiveEth2P2PNetwork(
         config.getSpec(),
@@ -215,7 +217,7 @@ public class Eth2P2PNetworkBuilder {
         gossipEncoding,
         config.getGossipConfigurator(),
         processedAttestationSubscriptionProvider,
-        dasExtraCustodySubnetCount,
+        dasExtraCustodySubnetCountOpt,
         config.isAllTopicsFilterEnabled());
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkBuilder.java
@@ -197,7 +197,8 @@ public class Eth2P2PNetworkBuilder {
 
     final GossipForkManager gossipForkManager = buildGossipForkManager(gossipEncoding, network);
 
-    int dasExtraCustodySubnetCount = config.getDasExtraCustodySubnetCount(spec.forMilestone(SpecMilestone.EIP7594));
+    int dasExtraCustodySubnetCount =
+        config.getDasExtraCustodySubnetCount(spec.forMilestone(SpecMilestone.EIP7594));
 
     return new ActiveEth2P2PNetwork(
         config.getSpec(),

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -25,8 +25,11 @@ import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.p2p.discovery.DiscoveryConfig;
 import tech.pegasys.teku.networking.p2p.network.config.NetworkConfig;
 import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecVersion;
 import tech.pegasys.teku.spec.config.NetworkingSpecConfig;
 import tech.pegasys.teku.spec.config.SpecConfig;
+import tech.pegasys.teku.spec.config.SpecConfigEip7594;
+import tech.pegasys.teku.spec.logic.common.helpers.MathHelpers;
 
 public class P2PConfig {
 
@@ -129,8 +132,22 @@ public class P2PConfig {
     return subscribeAllSubnetsEnabled;
   }
 
-  public int getDasExtraCustodySubnetCount() {
-    return dasExtraCustodySubnetCount;
+  public int getDasExtraCustodySubnetCount(SpecVersion specVersion) {
+    SpecConfigEip7594 configEip7594 =
+            SpecConfigEip7594.required(specVersion.getConfig());
+    int minCustodyRequirement = configEip7594.getCustodyRequirement();
+    return getTotalCustodySubnetCount(specVersion) - minCustodyRequirement;
+  }
+
+  public int getTotalCustodySubnetCount(SpecVersion specVersion) {
+    SpecConfigEip7594 configEip7594 =
+            SpecConfigEip7594.required(specVersion.getConfig());
+    int minCustodyRequirement = configEip7594.getCustodyRequirement();
+    int maxSubnets = configEip7594.getDataColumnSidecarSubnetCount();
+    return
+            Integer.min(
+                    maxSubnets,
+                    MathHelpers.intPlusMaxIntCapped(minCustodyRequirement, dasExtraCustodySubnetCount));
   }
 
   public int getPeerRateLimit() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/P2PConfig.java
@@ -133,21 +133,18 @@ public class P2PConfig {
   }
 
   public int getDasExtraCustodySubnetCount(SpecVersion specVersion) {
-    SpecConfigEip7594 configEip7594 =
-            SpecConfigEip7594.required(specVersion.getConfig());
+    SpecConfigEip7594 configEip7594 = SpecConfigEip7594.required(specVersion.getConfig());
     int minCustodyRequirement = configEip7594.getCustodyRequirement();
     return getTotalCustodySubnetCount(specVersion) - minCustodyRequirement;
   }
 
   public int getTotalCustodySubnetCount(SpecVersion specVersion) {
-    SpecConfigEip7594 configEip7594 =
-            SpecConfigEip7594.required(specVersion.getConfig());
+    SpecConfigEip7594 configEip7594 = SpecConfigEip7594.required(specVersion.getConfig());
     int minCustodyRequirement = configEip7594.getCustodyRequirement();
     int maxSubnets = configEip7594.getDataColumnSidecarSubnetCount();
-    return
-            Integer.min(
-                    maxSubnets,
-                    MathHelpers.intPlusMaxIntCapped(minCustodyRequirement, dasExtraCustodySubnetCount));
+    return Integer.min(
+        maxSubnets,
+        MathHelpers.intPlusMaxIntCapped(minCustodyRequirement, dasExtraCustodySubnetCount));
   }
 
   public int getPeerRateLimit() {

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetBackboneSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetBackboneSubscriber.java
@@ -28,21 +28,18 @@ import tech.pegasys.teku.spec.logic.common.helpers.MathHelpers;
 public class DataColumnSidecarSubnetBackboneSubscriber implements SlotEventsChannel {
   private final Eth2P2PNetwork eth2P2PNetwork;
   private final UInt256 nodeId;
-  private final int extraVoluntarySubnetCount;
+  private final int totalSubnetCount;
   private final Spec spec;
 
   private IntSet currentSubscribedSubnets = IntSet.of();
   private UInt64 lastEpoch = UInt64.MAX_VALUE;
 
   public DataColumnSidecarSubnetBackboneSubscriber(
-      final Spec spec,
-      final Eth2P2PNetwork eth2P2PNetwork,
-      UInt256 nodeId,
-      int extraVoluntarySubnetCount) {
+      final Spec spec, final Eth2P2PNetwork eth2P2PNetwork, UInt256 nodeId, int totalSubnetCount) {
     this.spec = spec;
     this.eth2P2PNetwork = eth2P2PNetwork;
     this.nodeId = nodeId;
-    this.extraVoluntarySubnetCount = extraVoluntarySubnetCount;
+    this.totalSubnetCount = totalSubnetCount;
   }
 
   private void subscribeToSubnets(final Collection<Integer> newSubscriptions) {
@@ -64,14 +61,6 @@ public class DataColumnSidecarSubnetBackboneSubscriber implements SlotEventsChan
     currentSubscribedSubnets = newSubscriptionsSet;
   }
 
-  private int getTotalSubnetCount(final UInt64 epoch) {
-    SpecConfigEip7594 configEip7594 = SpecConfigEip7594.required(spec.atEpoch(epoch).getConfig());
-    return Integer.min(
-        configEip7594.getDataColumnSidecarSubnetCount(),
-        MathHelpers.intPlusMaxIntCapped(
-            configEip7594.getCustodyRequirement(), extraVoluntarySubnetCount));
-  }
-
   private void onEpoch(final UInt64 epoch) {
     spec.atEpoch(epoch)
         .miscHelpers()
@@ -80,7 +69,7 @@ public class DataColumnSidecarSubnetBackboneSubscriber implements SlotEventsChan
             eip7594Spec -> {
               List<UInt64> subnets =
                   eip7594Spec.computeDataColumnSidecarBackboneSubnets(
-                      nodeId, epoch, getTotalSubnetCount(epoch));
+                      nodeId, epoch, totalSubnetCount);
               subscribeToSubnets(subnets.stream().map(UInt64::intValue).toList());
             });
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetBackboneSubscriber.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/subnets/DataColumnSidecarSubnetBackboneSubscriber.java
@@ -22,8 +22,6 @@ import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.eth2.Eth2P2PNetwork;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.config.SpecConfigEip7594;
-import tech.pegasys.teku.spec.logic.common.helpers.MathHelpers;
 
 public class DataColumnSidecarSubnetBackboneSubscriber implements SlotEventsChannel {
   private final Eth2P2PNetwork eth2P2PNetwork;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/GossipTopicDasPeerCustodyTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/GossipTopicDasPeerCustodyTracker.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.networking.eth2.peers;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -21,7 +22,11 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
 import tech.pegasys.teku.networking.eth2.gossip.encoding.GossipEncoding;
 import tech.pegasys.teku.networking.eth2.gossip.topics.GossipTopics;
 import tech.pegasys.teku.networking.p2p.gossip.GossipNetwork;
@@ -33,6 +38,7 @@ import tech.pegasys.teku.statetransition.datacolumns.retriever.DasPeerCustodyCou
 
 public class GossipTopicDasPeerCustodyTracker
     implements DasPeerCustodyCountSupplier, PeerConnectedSubscriber<Eth2Peer> {
+  private static final Logger LOG = LogManager.getLogger("das-nyota");
 
   public static final int NO_SUBNET_COUNT_INFO = -1;
 
@@ -44,14 +50,19 @@ public class GossipTopicDasPeerCustodyTracker
   private final Map<UInt256, Entry> connectedPeerExtraSubnets = new ConcurrentHashMap<>();
 
   public GossipTopicDasPeerCustodyTracker(
-      Spec spec,
-      GossipNetwork gossipNetwork,
-      GossipEncoding gossipEncoding,
-      Supplier<Optional<ForkInfo>> currentForkInfoSupplier) {
+          Spec spec,
+          GossipNetwork gossipNetwork,
+          GossipEncoding gossipEncoding,
+          Supplier<Optional<ForkInfo>> currentForkInfoSupplier,
+          AsyncRunner asyncRunner) {
     this.spec = spec;
     this.gossipNetwork = gossipNetwork;
     this.gossipEncoding = gossipEncoding;
     this.currentForkInfoSupplier = currentForkInfoSupplier;
+    asyncRunner.runWithFixedDelay(
+        this::refreshExistingSubscriptions,
+        Duration.ofSeconds(1),
+        e -> LOG.warn("[nyota] Error {}", e, e));
   }
 
   @Override
@@ -76,7 +87,7 @@ public class GossipTopicDasPeerCustodyTracker
         .orElse(Collections.emptySet());
   }
 
-  private void refreshExistingSubscriptions() {
+  private synchronized void refreshExistingSubscriptions() {
     Map<String, Collection<NodeId>> subscribersByTopic = gossipNetwork.getSubscribersByTopic();
     Set<String> dasTopics = getCurrentDasTopics();
     record NodeTopic(NodeId nodeId, String topic) {}

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/GossipTopicDasPeerCustodyTracker.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/GossipTopicDasPeerCustodyTracker.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -50,11 +49,11 @@ public class GossipTopicDasPeerCustodyTracker
   private final Map<UInt256, Entry> connectedPeerExtraSubnets = new ConcurrentHashMap<>();
 
   public GossipTopicDasPeerCustodyTracker(
-          Spec spec,
-          GossipNetwork gossipNetwork,
-          GossipEncoding gossipEncoding,
-          Supplier<Optional<ForkInfo>> currentForkInfoSupplier,
-          AsyncRunner asyncRunner) {
+      Spec spec,
+      GossipNetwork gossipNetwork,
+      GossipEncoding gossipEncoding,
+      Supplier<Optional<ForkInfo>> currentForkInfoSupplier,
+      AsyncRunner asyncRunner) {
     this.spec = spec;
     this.gossipNetwork = gossipNetwork;
     this.gossipEncoding = gossipEncoding;

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetworkTest.java
@@ -292,7 +292,7 @@ public class ActiveEth2P2PNetworkTest {
             gossipEncoding,
             gossipConfigurator,
             processedAttestationSubscriptionProvider,
-            Optional.empty(),
+            0,
             true);
 
     assertThat(network.isCloseToInSync()).isFalse();
@@ -330,7 +330,7 @@ public class ActiveEth2P2PNetworkTest {
         gossipEncoding,
         gossipConfigurator,
         processedAttestationSubscriptionProvider,
-        Optional.empty(),
+        0,
         true);
   }
 }

--- a/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
+++ b/networking/eth2/src/testFixtures/java/tech/pegasys/teku/networking/eth2/Eth2P2PNetworkFactory.java
@@ -359,7 +359,7 @@ public class Eth2P2PNetworkFactory {
             gossipEncoding,
             GossipConfigurator.NOOP,
             processedAttestationSubscriptionProvider,
-            Optional.empty(),
+            0,
             config.isAllTopicsFilterEnabled());
       }
     }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -636,15 +636,14 @@ public class BeaconChainController extends Service implements BeaconChainControl
                 .thenApply(sbb -> sbb.flatMap(SignedBeaconBlock::getBeaconBlock))
                 .join();
 
-    int dasExtraCustodySubnetCount = beaconConfig.p2pConfig().getDasExtraCustodySubnetCount();
     SpecConfigEip7594 configEip7594 =
         SpecConfigEip7594.required(spec.forMilestone(SpecMilestone.EIP7594).getConfig());
     int minCustodyRequirement = configEip7594.getCustodyRequirement();
     int maxSubnets = configEip7594.getDataColumnSidecarSubnetCount();
     int totalMyCustodySubnets =
-        Integer.min(
-            maxSubnets,
-            MathHelpers.intPlusMaxIntCapped(minCustodyRequirement, dasExtraCustodySubnetCount));
+        beaconConfig
+            .p2pConfig()
+            .getTotalCustodySubnetCount(spec.forMilestone(SpecMilestone.EIP7594));
 
     DataColumnSidecarCustodyImpl dataColumnSidecarCustodyImpl =
         new DataColumnSidecarCustodyImpl(

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -664,7 +664,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             spec,
             p2pNetwork,
             beaconConfig.p2pConfig().getGossipEncoding(),
-            () -> recentChainData.getCurrentForkInfo());
+            () -> recentChainData.getCurrentForkInfo(),
+            operationPoolAsyncRunner);
 
     p2pNetwork.subscribeConnect(peerCustodyTracker);
     DasPeerCustodyCountSupplier custodyCountSupplier =
@@ -991,7 +992,13 @@ public class BeaconChainController extends Service implements BeaconChainControl
     LOG.debug("BeaconChainController.initDataColumnSidecarSubnetBackboneSubscriber");
     DataColumnSidecarSubnetBackboneSubscriber subnetBackboneSubscriber =
         new DataColumnSidecarSubnetBackboneSubscriber(
-            spec, p2pNetwork, nodeId, beaconConfig.p2pConfig().getDasExtraCustodySubnetCount());
+            spec,
+            p2pNetwork,
+            nodeId,
+            beaconConfig
+                .p2pConfig()
+                .getTotalCustodySubnetCount(spec.forMilestone(SpecMilestone.EIP7594)));
+
     eventChannels.subscribe(SlotEventsChannel.class, subnetBackboneSubscriber);
   }
 

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -116,7 +116,6 @@ import tech.pegasys.teku.spec.datastructures.state.beaconstate.BeaconState;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerBlockProductionManager;
 import tech.pegasys.teku.spec.executionlayer.ExecutionLayerChannel;
-import tech.pegasys.teku.spec.logic.common.helpers.MathHelpers;
 import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportResult;
 import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Fix the `GossipTopicDasPeerCustodyTracker` to track remote subscribtions periodically
- `P2PConfig.getDasExtraCustodySubnetCount`: cap the value in the config to avoid overflows 
- `SimpleSidecarRetriever`: Add more synchronized
- `SimpleSidecarRetriever`: add logging stats on the number of custody peers available for columns
