### PR TITLE
Less potential deadlocks

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
@@ -57,11 +57,13 @@ public class DasCustodySync implements SlotEventsChannel {
     this(custody, retriever, 10 * 1024, 2 * 1024);
   }
 
-  private synchronized void onRequestComplete(PendingRequest request, DataColumnSidecar response) {
+  private void onRequestComplete(PendingRequest request, DataColumnSidecar response) {
     custody.onNewValidatedDataColumnSidecar(response);
-    pendingRequests.remove(request.columnId);
-    syncedColumnCount.incrementAndGet();
-    fillUpIfNeeded();
+    synchronized (this) {
+      pendingRequests.remove(request.columnId);
+      syncedColumnCount.incrementAndGet();
+      fillUpIfNeeded();
+    }
   }
 
   private boolean wasCancelledImplicitly(Throwable exception) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -93,10 +94,9 @@ public class DataColumnSidecarCustodyImpl
   private final UInt64 eip7594StartEpoch;
   private final Duration requestTimeout;
 
-  private UInt64 currentSlot = null;
-
   @VisibleForTesting
-  Map<DataColumnIdentifier, List<SafeFuture<DataColumnSidecar>>> pendingRequests = new HashMap<>();
+  final PendingRequests pendingRequests = new PendingRequests();
+  private volatile UInt64 currentSlot = null;
 
   public DataColumnSidecarCustodyImpl(
       Spec spec,
@@ -144,22 +144,15 @@ public class DataColumnSidecarCustodyImpl
   }
 
   @Override
-  public synchronized void onNewValidatedDataColumnSidecar(DataColumnSidecar dataColumnSidecar) {
+  public void onNewValidatedDataColumnSidecar(DataColumnSidecar dataColumnSidecar) {
     if (isMyCustody(dataColumnSidecar.getSlot(), dataColumnSidecar.getIndex())) {
       db.addSidecar(dataColumnSidecar);
       final List<SafeFuture<DataColumnSidecar>> pendingRequests =
           this.pendingRequests.remove(DataColumnIdentifier.createFromSidecar(dataColumnSidecar));
-      if (pendingRequests != null) {
-        for (SafeFuture<DataColumnSidecar> pendingRequest : pendingRequests) {
-          pendingRequest.complete(dataColumnSidecar);
-        }
+      for (SafeFuture<DataColumnSidecar> pendingRequest : pendingRequests) {
+        pendingRequest.complete(dataColumnSidecar);
       }
     }
-  }
-
-  private synchronized void clearCancelledPendingRequests() {
-    pendingRequests.values().forEach(promises -> promises.removeIf(CompletableFuture::isDone));
-    pendingRequests.entrySet().removeIf(e -> e.getValue().isEmpty());
   }
 
   private boolean isMyCustody(UInt64 slot, UInt64 columnIndex) {
@@ -184,7 +177,6 @@ public class DataColumnSidecarCustodyImpl
               if (existingColumn.isPresent()) {
                 return SafeFuture.completedFuture(existingColumn);
               } else {
-                clearCancelledPendingRequests();
                 SafeFuture<DataColumnSidecar> promise = new SafeFuture<>();
                 addPendingRequest(columnId, promise);
                 return promise
@@ -202,9 +194,9 @@ public class DataColumnSidecarCustodyImpl
             });
   }
 
-  private synchronized void addPendingRequest(
+  private void addPendingRequest(
       final DataColumnIdentifier columnId, final SafeFuture<DataColumnSidecar> promise) {
-    pendingRequests.computeIfAbsent(columnId, __ -> new ArrayList<>()).add(promise);
+    pendingRequests.add(columnId, promise);
   }
 
   private void onEpoch(UInt64 epoch) {
@@ -320,5 +312,27 @@ public class DataColumnSidecarCustodyImpl
                                     colId ->
                                         new ColumnSlotAndIdentifier(slotCustody.slot(), colId)))
                     .toList());
+  }
+
+  @VisibleForTesting
+  static class PendingRequests {
+
+    final Map<DataColumnIdentifier, List<SafeFuture<DataColumnSidecar>>> requests = new HashMap<>();
+
+    synchronized void add(
+        final DataColumnIdentifier columnId, final SafeFuture<DataColumnSidecar> promise) {
+      clearCancelledPendingRequests();
+      requests.computeIfAbsent(columnId, __ -> new ArrayList<>()).add(promise);
+    }
+
+    synchronized List<SafeFuture<DataColumnSidecar>> remove(final DataColumnIdentifier columnId) {
+      List<SafeFuture<DataColumnSidecar>> ret = requests.remove(columnId);
+      return ret == null ? Collections.emptyList() : ret;
+    }
+
+    private void clearCancelledPendingRequests() {
+      requests.values().forEach(promises -> promises.removeIf(CompletableFuture::isDone));
+      requests.entrySet().removeIf(e -> e.getValue().isEmpty());
+    }
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -94,8 +94,7 @@ public class DataColumnSidecarCustodyImpl
   private final UInt64 eip7594StartEpoch;
   private final Duration requestTimeout;
 
-  @VisibleForTesting
-  final PendingRequests pendingRequests = new PendingRequests();
+  @VisibleForTesting final PendingRequests pendingRequests = new PendingRequests();
   private volatile UInt64 currentSlot = null;
 
   public DataColumnSidecarCustodyImpl(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -38,10 +39,10 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
       DataColumnIdentifier columnIdentifier,
       SafeFuture<DataColumnSidecar> promise) {}
 
-  private List<RequestEntry> bufferedRequests = new ArrayList<>();
+  private final ConcurrentLinkedQueue<RequestEntry> bufferedRequests = new ConcurrentLinkedQueue<>();
 
   @Override
-  public synchronized SafeFuture<DataColumnSidecar> requestDataColumnSidecar(
+  public SafeFuture<DataColumnSidecar> requestDataColumnSidecar(
       UInt256 nodeId, DataColumnIdentifier columnIdentifier) {
     RequestEntry entry = new RequestEntry(nodeId, columnIdentifier, new SafeFuture<>());
     bufferedRequests.add(entry);
@@ -50,13 +51,9 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
 
   @Override
   public void flush() {
-    final List<RequestEntry> requests;
-    synchronized (this) {
-      requests = bufferedRequests;
-      bufferedRequests = new ArrayList<>();
-    }
     Map<UInt256, List<RequestEntry>> byNodes = new HashMap<>();
-    for (RequestEntry request : requests) {
+    RequestEntry request;
+    while((request = bufferedRequests.poll()) != null) {
       byNodes.computeIfAbsent(request.nodeId, __ -> new ArrayList<>()).add(request);
     }
     for (Map.Entry<UInt256, List<RequestEntry>> entry : byNodes.entrySet()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
@@ -39,7 +39,8 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
       DataColumnIdentifier columnIdentifier,
       SafeFuture<DataColumnSidecar> promise) {}
 
-  private final ConcurrentLinkedQueue<RequestEntry> bufferedRequests = new ConcurrentLinkedQueue<>();
+  private final ConcurrentLinkedQueue<RequestEntry> bufferedRequests =
+      new ConcurrentLinkedQueue<>();
 
   @Override
   public SafeFuture<DataColumnSidecar> requestDataColumnSidecar(
@@ -53,7 +54,7 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
   public void flush() {
     Map<UInt256, List<RequestEntry>> byNodes = new HashMap<>();
     RequestEntry request;
-    while((request = bufferedRequests.poll()) != null) {
+    while ((request = bufferedRequests.poll()) != null) {
       byNodes.computeIfAbsent(request.nodeId, __ -> new ArrayList<>()).add(request);
     }
     for (Map.Entry<UInt256, List<RequestEntry>> entry : byNodes.entrySet()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -170,7 +170,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     private final MiscHelpersEip7594 specHelpers;
 
     private final Map<UInt64, DataColumnSidecar> existingSidecarsByColIdx = new HashMap<>();
-    private final Map<UInt64, List<CompletableFuture<DataColumnSidecar>>> promisesByColIdx =
+    private final Map<UInt64, List<SafeFuture<DataColumnSidecar>>> promisesByColIdx =
         new HashMap<>();
     private List<SafeFuture<DataColumnSidecar>> recoveryRequests;
     private boolean recovered = false;
@@ -183,9 +183,9 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     }
 
     public synchronized void addRequest(
-        UInt64 columnIndex, CompletableFuture<DataColumnSidecar> promise) {
+        UInt64 columnIndex, SafeFuture<DataColumnSidecar> promise) {
       if (recovered) {
-        promise.complete(existingSidecarsByColIdx.get(columnIndex));
+        promise.completeAsync(existingSidecarsByColIdx.get(columnIndex), asyncRunner);
       } else {
         promisesByColIdx.computeIfAbsent(columnIndex, __ -> new ArrayList<>()).add(promise);
       }
@@ -212,7 +212,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
       promisesByColIdx.forEach(
           (key, value) -> {
             DataColumnSidecar columnSidecar = existingSidecarsByColIdx.get(key);
-            value.forEach(promise -> promise.complete(columnSidecar));
+            value.forEach(promise -> promise.completeAsync(columnSidecar, asyncRunner));
           });
       promisesByColIdx.clear();
       RecoveringSidecarRetriever.this.recoveryComplete(this);
@@ -245,8 +245,8 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
           .flatMap(Collection::stream)
           .forEach(
               promise ->
-                  promise.completeExceptionally(
-                      new NotOnCanonicalChainException("Canonical block changed")));
+                  promise.completeExceptionallyAsync(
+                      new NotOnCanonicalChainException("Canonical block changed"), asyncRunner));
     }
 
     private void recover() {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -182,8 +181,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
       this.specHelpers = specHelpers;
     }
 
-    public synchronized void addRequest(
-        UInt64 columnIndex, SafeFuture<DataColumnSidecar> promise) {
+    public synchronized void addRequest(UInt64 columnIndex, SafeFuture<DataColumnSidecar> promise) {
       if (recovered) {
         promise.completeAsync(existingSidecarsByColIdx.get(columnIndex), asyncRunner);
       } else {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -187,9 +187,7 @@ public class SimpleSidecarRetriever
       RetrieveRequest request, DataColumnSidecar maybeResult, Throwable maybeError) {
     if (maybeResult != null) {
       pendingRequests.remove(request.columnId);
-      asyncRunner
-          .runAsync(() -> request.result.complete(maybeResult))
-          .ifExceptionGetsHereRaiseABug();
+      request.result.completeAsync(maybeResult, asyncRunner);
       request.peerSearchRequest.dispose();
       retrieveCounter.incrementAndGet();
     } else {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
@@ -92,6 +92,6 @@ public class DataColumnSidecarCustodyImplTest {
     custody.onNewValidatedDataColumnSidecar(sidecar1);
     assertThat(fRet4.get().get()).isEqualTo(sidecar1);
 
-    assertThat(custody.pendingRequests).isEmpty();
+    assertThat(custody.pendingRequests.requests).isEmpty();
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarDBStub;
 
 public class RecoveringSidecarRetrieverTest {
 
+  final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner();
   final Spec spec = TestSpecFactory.createMinimalEip7594();
   final DataColumnSidecarDB db = new DataColumnSidecarDBStub();
   final CanonicalBlockResolverStub blockResolver = new CanonicalBlockResolverStub(spec);
@@ -83,7 +84,7 @@ public class RecoveringSidecarRetrieverTest {
             miscHelpers,
             blockResolver,
             db,
-            new StubAsyncRunner(),
+            stubAsyncRunner,
             Duration.ofSeconds(1),
             128);
     List<Blob> blobs = Stream.generate(dataStructureUtil::randomBlob).limit(blobCount).toList();
@@ -116,6 +117,8 @@ public class RecoveringSidecarRetrieverTest {
               req.promise()
                   .complete(sidecars.get(req.columnId().identifier().getIndex().intValue()));
             });
+
+    stubAsyncRunner.executeQueuedActions();
 
     assertThat(res0.get(1, TimeUnit.SECONDS)).isEqualTo(sidecars.get(0));
     assertThat(res1.get(1, TimeUnit.SECONDS)).isEqualTo(sidecars.get(1));

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -309,6 +309,15 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     ifExceptionGetsHereRaiseABug(this);
   }
 
+  public void completeAsync(T value, AsyncRunner asyncRunner) {
+    asyncRunner.runAsync(() -> complete(value)).ifExceptionGetsHereRaiseABug();
+  }
+
+  public void completeExceptionallyAsync(Throwable exception, AsyncRunner asyncRunner) {
+    asyncRunner.runAsync(() -> completeExceptionally(exception)).ifExceptionGetsHereRaiseABug();
+  }
+
+
   public void finish(final Runnable onSuccess, final Consumer<Throwable> onError) {
     finish(result -> onSuccess.run(), onError);
   }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -317,7 +317,6 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     asyncRunner.runAsync(() -> completeExceptionally(exception)).ifExceptionGetsHereRaiseABug();
   }
 
-
   public void finish(final Runnable onSuccess, final Consumer<Throwable> onError) {
     finish(result -> onSuccess.run(), onError);
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

To avoid deadlock we should either: 
- synchronize just local code which doesn't invoke outer components
- invoking `SafeFuture.complete` asynchronously
- invoke outer components outside of lock when possible 