### PR TITLE
Refactor DataColumnSidecarCustodyImpl

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustody.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustody.java
@@ -1,12 +1,19 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.statetransition.datacolumns;
 
 import com.google.common.annotations.VisibleForTesting;
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
-import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -17,6 +24,11 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeoutException;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 
 public class DasLongPollCustody implements UpdatableDataColumnSidecarCustody {
 
@@ -48,7 +60,8 @@ public class DasLongPollCustody implements UpdatableDataColumnSidecarCustody {
   @Override
   public SafeFuture<Optional<DataColumnSidecar>> getCustodyDataColumnSidecar(
       DataColumnIdentifier columnId) {
-    return delegate.getCustodyDataColumnSidecar(columnId)
+    return delegate
+        .getCustodyDataColumnSidecar(columnId)
         .thenCompose(
             existingColumn -> {
               if (existingColumn.isPresent()) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustody.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustody.java
@@ -1,0 +1,104 @@
+package tech.pegasys.teku.statetransition.datacolumns;
+
+import com.google.common.annotations.VisibleForTesting;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.exceptions.ExceptionUtil;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
+
+public class DasLongPollCustody implements UpdatableDataColumnSidecarCustody {
+
+  private final UpdatableDataColumnSidecarCustody delegate;
+  private final AsyncRunner asyncRunner;
+  private final Duration longPollRequestTimeout;
+
+  @VisibleForTesting final PendingRequests pendingRequests = new PendingRequests();
+
+  public DasLongPollCustody(
+      UpdatableDataColumnSidecarCustody delegate,
+      AsyncRunner asyncRunner,
+      Duration longPollRequestTimeout) {
+    this.delegate = delegate;
+    this.asyncRunner = asyncRunner;
+    this.longPollRequestTimeout = longPollRequestTimeout;
+  }
+
+  @Override
+  public void onNewValidatedDataColumnSidecar(DataColumnSidecar dataColumnSidecar) {
+    delegate.onNewValidatedDataColumnSidecar(dataColumnSidecar);
+    final List<SafeFuture<DataColumnSidecar>> pendingRequests =
+        this.pendingRequests.remove(DataColumnIdentifier.createFromSidecar(dataColumnSidecar));
+    for (SafeFuture<DataColumnSidecar> pendingRequest : pendingRequests) {
+      pendingRequest.complete(dataColumnSidecar);
+    }
+  }
+
+  @Override
+  public SafeFuture<Optional<DataColumnSidecar>> getCustodyDataColumnSidecar(
+      DataColumnIdentifier columnId) {
+    return delegate.getCustodyDataColumnSidecar(columnId)
+        .thenCompose(
+            existingColumn -> {
+              if (existingColumn.isPresent()) {
+                return SafeFuture.completedFuture(existingColumn);
+              } else {
+                SafeFuture<DataColumnSidecar> promise = new SafeFuture<>();
+                addPendingRequest(columnId, promise);
+                return promise
+                    .orTimeout(asyncRunner, longPollRequestTimeout)
+                    .thenApply(Optional::of)
+                    .exceptionally(
+                        err -> {
+                          if (ExceptionUtil.hasCause(err, TimeoutException.class)) {
+                            return Optional.empty();
+                          } else {
+                            throw new CompletionException(err);
+                          }
+                        });
+              }
+            });
+  }
+
+  @Override
+  public SafeFuture<List<ColumnSlotAndIdentifier>> retrieveMissingColumns() {
+    return delegate.retrieveMissingColumns();
+  }
+
+  private void addPendingRequest(
+      final DataColumnIdentifier columnId, final SafeFuture<DataColumnSidecar> promise) {
+    pendingRequests.add(columnId, promise);
+  }
+
+  @VisibleForTesting
+  static class PendingRequests {
+    final Map<DataColumnIdentifier, List<SafeFuture<DataColumnSidecar>>> requests = new HashMap<>();
+
+    synchronized void add(
+        final DataColumnIdentifier columnId, final SafeFuture<DataColumnSidecar> promise) {
+      clearCancelledPendingRequests();
+      requests.computeIfAbsent(columnId, __ -> new ArrayList<>()).add(promise);
+    }
+
+    synchronized List<SafeFuture<DataColumnSidecar>> remove(final DataColumnIdentifier columnId) {
+      List<SafeFuture<DataColumnSidecar>> ret = requests.remove(columnId);
+      return ret == null ? Collections.emptyList() : ret;
+    }
+
+    private void clearCancelledPendingRequests() {
+      requests.values().forEach(promises -> promises.removeIf(CompletableFuture::isDone));
+      requests.entrySet().removeIf(e -> e.getValue().isEmpty());
+    }
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.datacolumns;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.apache.tuweni.units.bigints.UInt256;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.config.SpecConfigEip7594;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+
+@SuppressWarnings("JavaCase")
+public class DasLongPollCustodyTest {
+  final StubTimeProvider stubTimeProvider = StubTimeProvider.withTimeInSeconds(0);
+  final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner(stubTimeProvider);
+
+  final Spec spec = TestSpecFactory.createMinimalEip7594();
+  final DataColumnSidecarDB db = new DataColumnSidecarDBStub();
+  final CanonicalBlockResolverStub blockResolver = new CanonicalBlockResolverStub(spec);
+  final UInt256 myNodeId = UInt256.ONE;
+
+  final SpecConfigEip7594 config =
+      SpecConfigEip7594.required(spec.forMilestone(SpecMilestone.EIP7594).getConfig());
+  final int subnetCount = config.getDataColumnSidecarSubnetCount();
+  final int custodyCount = config.getCustodyRequirement();
+
+  final DataColumnSidecarCustodyImpl custodyImpl =
+      new DataColumnSidecarCustodyImpl(spec, blockResolver, db, myNodeId, subnetCount);
+
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(0, spec);
+
+  private DataColumnSidecar createSidecar(BeaconBlock block, int column) {
+    return dataStructureUtil.randomDataColumnSidecar(createSigned(block), UInt64.valueOf(column));
+  }
+
+  private SignedBeaconBlockHeader createSigned(BeaconBlock block) {
+    return dataStructureUtil.signedBlock(block).asHeader();
+  }
+
+  @Test
+  void testLongPollingColumnRequest() throws Exception {
+    Duration longPollTimeout = Duration.ofMillis(200);
+    DasLongPollCustody custody =
+        new DasLongPollCustody(custodyImpl, stubAsyncRunner, longPollTimeout);
+
+    BeaconBlock block = blockResolver.addBlock(10, true);
+    DataColumnSidecar sidecar0 = createSidecar(block, 0);
+    DataColumnIdentifier columnId0 = DataColumnIdentifier.createFromSidecar(sidecar0);
+    DataColumnSidecar sidecar1 = createSidecar(block, 1);
+    DataColumnIdentifier columnId1 = DataColumnIdentifier.createFromSidecar(sidecar1);
+
+    SafeFuture<Optional<DataColumnSidecar>> fRet0 = custody.getCustodyDataColumnSidecar(columnId0);
+    SafeFuture<Optional<DataColumnSidecar>> fRet0_1 =
+        custody.getCustodyDataColumnSidecar(columnId0);
+    SafeFuture<Optional<DataColumnSidecar>> fRet1 = custody.getCustodyDataColumnSidecar(columnId1);
+
+    stubTimeProvider.advanceTimeBy(longPollTimeout.minus(Duration.ofMillis(1)));
+    stubAsyncRunner.executeDueActions();
+
+    assertThat(fRet0).isNotDone();
+    assertThat(fRet0_1).isNotDone();
+    assertThat(fRet1).isNotDone();
+
+    custody.onNewValidatedDataColumnSidecar(sidecar0);
+
+    assertThat(fRet0.get(1, TimeUnit.SECONDS)).contains(sidecar0);
+    assertThat(fRet0_1.get(1, TimeUnit.SECONDS)).contains(sidecar0);
+    assertThat(fRet1).isNotDone();
+
+    stubTimeProvider.advanceTimeBy(Duration.ofMillis(2));
+    stubAsyncRunner.executeDueActions();
+
+    assertThat(fRet0.get(1, TimeUnit.SECONDS)).contains(sidecar0);
+    assertThat(fRet0_1.get(1, TimeUnit.SECONDS)).contains(sidecar0);
+    assertThat(fRet1.get(1, TimeUnit.SECONDS)).isEmpty();
+  }
+}

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
@@ -47,7 +47,6 @@ public class DasLongPollCustodyTest {
   final SpecConfigEip7594 config =
       SpecConfigEip7594.required(spec.forMilestone(SpecMilestone.EIP7594).getConfig());
   final int subnetCount = config.getDataColumnSidecarSubnetCount();
-  final int custodyCount = config.getCustodyRequirement();
 
   final DataColumnSidecarCustodyImpl custodyImpl =
       new DataColumnSidecarCustodyImpl(spec, blockResolver, db, myNodeId, subnetCount);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.statetransition.datacolumns;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -58,12 +57,7 @@ public class DataColumnSidecarCustodyImplTest {
   @SuppressWarnings("JavaCase")
   void sanityTest() throws Throwable {
     DataColumnSidecarCustodyImpl custody =
-        new DataColumnSidecarCustodyImpl(
-            spec,
-            blockResolver,
-            db,
-            myNodeId,
-            subnetCount);
+        new DataColumnSidecarCustodyImpl(spec, blockResolver, db, myNodeId, subnetCount);
     BeaconBlock block = blockResolver.addBlock(10, true);
     DataColumnSidecar sidecar0 = createSidecar(block, 0);
     DataColumnIdentifier columnId0 = DataColumnIdentifier.createFromSidecar(sidecar0);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
@@ -59,7 +59,11 @@ public class DataColumnSidecarCustodyImplTest {
   void sanityTest() throws Throwable {
     DataColumnSidecarCustodyImpl custody =
         new DataColumnSidecarCustodyImpl(
-            spec, blockResolver, db, myNodeId, subnetCount, Duration.ofMillis(200));
+            spec,
+            blockResolver,
+            db,
+            myNodeId,
+            subnetCount);
     BeaconBlock block = blockResolver.addBlock(10, true);
     DataColumnSidecar sidecar0 = createSidecar(block, 0);
     DataColumnIdentifier columnId0 = DataColumnIdentifier.createFromSidecar(sidecar0);
@@ -91,7 +95,5 @@ public class DataColumnSidecarCustodyImplTest {
 
     custody.onNewValidatedDataColumnSidecar(sidecar1);
     assertThat(fRet4.get().get()).isEqualTo(sidecar1);
-
-    assertThat(custody.pendingRequests.requests).isEmpty();
   }
 }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -20,7 +20,9 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -634,6 +636,38 @@ public class SafeFuture<T> extends CompletableFuture<T> {
   @Override
   public SafeFuture<T> orTimeout(final long timeout, final TimeUnit unit) {
     return (SafeFuture<T>) super.orTimeout(timeout, unit);
+  }
+
+  /**
+   * Schedules future timeout on the specified {@link AsyncRunner}
+   */
+  public SafeFuture<T> orTimeout(AsyncRunner async, final long timeout, final TimeUnit unit) {
+    return orTimeout(async, Duration.of(timeout, unit.toChronoUnit()));
+  }
+
+  /**
+   * Schedules future timeout on the specified {@link AsyncRunner}
+   */
+  public SafeFuture<T> orTimeout(AsyncRunner async, Duration timeout) {
+    if (!isDone()) {
+      SafeFuture<Void> timeoutInterruptor =
+          async.runAfterDelay(
+              () -> {
+                if (!SafeFuture.this.isDone()) {
+                  SafeFuture.this.completeExceptionally(new TimeoutException());
+                }
+              },
+              timeout);
+
+      return this.whenComplete(
+          (__, ex) -> {
+            if (ex == null && !timeoutInterruptor.isDone()) {
+              timeoutInterruptor.cancel(false);
+            }
+          });
+    } else {
+      return this;
+    }
   }
 
   /**

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/SafeFuture.java
@@ -20,7 +20,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
@@ -638,16 +637,12 @@ public class SafeFuture<T> extends CompletableFuture<T> {
     return (SafeFuture<T>) super.orTimeout(timeout, unit);
   }
 
-  /**
-   * Schedules future timeout on the specified {@link AsyncRunner}
-   */
+  /** Schedules future timeout on the specified {@link AsyncRunner} */
   public SafeFuture<T> orTimeout(AsyncRunner async, final long timeout, final TimeUnit unit) {
     return orTimeout(async, Duration.of(timeout, unit.toChronoUnit()));
   }
 
-  /**
-   * Schedules future timeout on the specified {@link AsyncRunner}
-   */
+  /** Schedules future timeout on the specified {@link AsyncRunner} */
   public SafeFuture<T> orTimeout(AsyncRunner async, Duration timeout) {
     if (!isDone()) {
       SafeFuture<Void> timeoutInterruptor =

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -661,16 +661,13 @@ public class BeaconChainController extends Service implements BeaconChainControl
 
     DataColumnSidecarCustodyImpl dataColumnSidecarCustodyImpl =
         new DataColumnSidecarCustodyImpl(
-            spec,
-            canonicalBlockResolver,
-            sidecarDB,
-            nodeId,
-            totalMyCustodySubnets);
+            spec, canonicalBlockResolver, sidecarDB, nodeId, totalMyCustodySubnets);
     eventChannels.subscribe(SlotEventsChannel.class, dataColumnSidecarCustodyImpl);
     eventChannels.subscribe(FinalizedCheckpointChannel.class, dataColumnSidecarCustodyImpl);
 
-    DasLongPollCustody custody = new DasLongPollCustody(
-        dataColumnSidecarCustodyImpl, operationPoolAsyncRunner, Duration.ofSeconds(5));
+    DasLongPollCustody custody =
+        new DasLongPollCustody(
+            dataColumnSidecarCustodyImpl, operationPoolAsyncRunner, Duration.ofSeconds(5));
     dataColumnSidecarManager.subscribeToValidDataColumnSidecars(
         custody::onNewValidatedDataColumnSidecar);
     // TODO fix this dirty hack

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -141,6 +141,7 @@ import tech.pegasys.teku.statetransition.block.FailedExecutionPool;
 import tech.pegasys.teku.statetransition.block.ReceivedBlockEventsChannel;
 import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolver;
 import tech.pegasys.teku.statetransition.datacolumns.DasCustodySync;
+import tech.pegasys.teku.statetransition.datacolumns.DasLongPollCustody;
 import tech.pegasys.teku.statetransition.datacolumns.DasSamplerImpl;
 import tech.pegasys.teku.statetransition.datacolumns.DasSamplerManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
@@ -664,15 +665,17 @@ public class BeaconChainController extends Service implements BeaconChainControl
             canonicalBlockResolver,
             sidecarDB,
             nodeId,
-            totalMyCustodySubnets,
-            Duration.ofSeconds(5));
+            totalMyCustodySubnets);
     eventChannels.subscribe(SlotEventsChannel.class, dataColumnSidecarCustodyImpl);
     eventChannels.subscribe(FinalizedCheckpointChannel.class, dataColumnSidecarCustodyImpl);
+
+    DasLongPollCustody custody = new DasLongPollCustody(
+        dataColumnSidecarCustodyImpl, operationPoolAsyncRunner, Duration.ofSeconds(5));
     dataColumnSidecarManager.subscribeToValidDataColumnSidecars(
-        dataColumnSidecarCustodyImpl::onNewValidatedDataColumnSidecar);
+        custody::onNewValidatedDataColumnSidecar);
     // TODO fix this dirty hack
     // This is to resolve the initialization loop Network <--> DAS Custody
-    this.dataColumnSidecarCustody.init(dataColumnSidecarCustodyImpl);
+    this.dataColumnSidecarCustody.init(custody);
 
     DataColumnPeerManagerImpl dasPeerManager = new DataColumnPeerManagerImpl();
     p2pNetwork.subscribeConnect(dasPeerManager);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Decompose `DataColumnSidecarCustodyImpl`: extract long polling functionality to a separate `DataColumnSidecarCustody` implementation (`DasLongPollCustody`)
- Make `DasLongPollCustody` to process timeout on a specified `AsyncRunner` to make it testable 