### PR TITLE
Bump reference tests to v1.5.0-alpha.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,7 +295,7 @@ allprojects {
   }
 }
 
-def refTestVersion = 'v1.5.0-alpha.2' // Arbitrary change to refresh cache number: 1
+def refTestVersion = 'v1.5.0-alpha.3' // Arbitrary change to refresh cache number: 1
 def blsRefTestVersion = 'v0.1.2'
 def refTestBaseUrl = 'https://github.com/ethereum/consensus-spec-tests/releases/download'
 def blsRefTestBaseUrl = 'https://github.com/ethereum/bls12-381-tests/releases/download'

--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -43,4 +43,9 @@ task generateReferenceTestClasses(type: JavaExec) {
   systemProperty("teku.ref-test-module.path", project.file("../eth-reference-tests").absolutePath)
 }
 
-compileReferenceTestJava.dependsOn(generateReferenceTestClasses)
+compileReferenceTestJava {
+  dependsOn generateReferenceTestClasses
+  // Fork worker to compile tests and avoid OoM errors during compilation
+  options.fork = true
+  options.forkOptions.memoryMaximumSize = "2048m"
+}

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/kzg/KzgVerifyCellKzgProofTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/kzg/KzgVerifyCellKzgProofTestExecutor.java
@@ -39,7 +39,7 @@ public class KzgVerifyCellKzgProofTestExecutor extends KzgTestExecutor {
               data.getInput().getCommitment(),
               new KZGCellWithColumnId(
                   data.getInput().getCell(),
-                  new KZGCellID(UInt64.valueOf(data.getInput().getCellId()))),
+                  new KZGCellID(UInt64.valueOf(data.getInput().getCellIndex()))),
               data.getInput().getProof());
     } catch (final RuntimeException ex) {
       actualVerificationResult = null;
@@ -66,8 +66,8 @@ public class KzgVerifyCellKzgProofTestExecutor extends KzgTestExecutor {
       @JsonProperty(value = "commitment", required = true)
       private String commitment;
 
-      @JsonProperty(value = "cell_id", required = true)
-      private Integer cellId;
+      @JsonProperty(value = "cell_index", required = true)
+      private Integer cellIndex;
 
       @JsonProperty(value = "cell", required = true)
       private String cell;
@@ -79,8 +79,8 @@ public class KzgVerifyCellKzgProofTestExecutor extends KzgTestExecutor {
         return KZGCommitment.fromHexString(commitment);
       }
 
-      public Integer getCellId() {
-        return cellId;
+      public Integer getCellIndex() {
+        return cellIndex;
       }
 
       public KZGCell getCell() {

--- a/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
+++ b/eth-reference-tests/src/referenceTest/java/tech/pegasys/teku/reference/phase0/ssz_static/SszTestExecutor.java
@@ -195,7 +195,10 @@ public class SszTestExecutor<T extends SszData> implements TestExecutor {
               new SszTestExecutor<>(
                   schemas ->
                       SchemaDefinitionsEip7594.required(schemas).getDataColumnSidecarSchema()))
-
+          .put(
+              "ssz_static/MatrixEntry",
+              new SszTestExecutor<>(
+                  schemas -> SchemaDefinitionsEip7594.required(schemas).getMatrixEntrySchema()))
           // Legacy Schemas (Not yet migrated to SchemaDefinitions)
           .put(
               "ssz_static/AttestationData", new SszTestExecutor<>(__ -> AttestationData.SSZ_SCHEMA))

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/eip7594/MatrixEntry.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/eip7594/MatrixEntry.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.Container4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZGProof;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
+
+public class MatrixEntry extends Container4<MatrixEntry, Cell, SszKZGProof, SszUInt64, SszUInt64> {
+
+  MatrixEntry(final MatrixEntrySchema matrixEntrySchema, final TreeNode backingTreeNode) {
+    super(matrixEntrySchema, backingTreeNode);
+  }
+
+  public MatrixEntry(
+      final MatrixEntrySchema schema,
+      final Cell cell,
+      final KZGProof kzgProof,
+      final UInt64 columnIndex,
+      final UInt64 rowIndex) {
+    super(
+        schema, cell, new SszKZGProof(kzgProof), SszUInt64.of(columnIndex), SszUInt64.of(rowIndex));
+  }
+
+  public MatrixEntry(
+      final MatrixEntrySchema schema,
+      final Cell cell,
+      final SszKZGProof sszKZGProof,
+      final SszUInt64 sszColumnIndex,
+      final SszUInt64 sszRowIndex) {
+    super(schema, cell, sszKZGProof, sszColumnIndex, sszRowIndex);
+  }
+
+  public Cell getCell() {
+    return getField0();
+  }
+
+  public KZGProof getKzgProof() {
+    return getField1().getKZGProof();
+  }
+
+  public UInt64 getColumnIndex() {
+    return getField2().get();
+  }
+
+  public UInt64 getRowIndex() {
+    return getField3().get();
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/eip7594/MatrixEntrySchema.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/eip7594/MatrixEntrySchema.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Consensys Software Inc., 2023
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594;
+
+import tech.pegasys.teku.infrastructure.ssz.containers.ContainerSchema4;
+import tech.pegasys.teku.infrastructure.ssz.primitive.SszUInt64;
+import tech.pegasys.teku.infrastructure.ssz.schema.SszPrimitiveSchemas;
+import tech.pegasys.teku.infrastructure.ssz.tree.TreeNode;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZGCell;
+import tech.pegasys.teku.kzg.KZGProof;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGProofSchema;
+
+public class MatrixEntrySchema
+    extends ContainerSchema4<MatrixEntry, Cell, SszKZGProof, SszUInt64, SszUInt64> {
+
+  MatrixEntrySchema(final CellSchema cellSchema) {
+    super(
+        "MatrixEntry",
+        namedSchema("cell", cellSchema),
+        namedSchema("kzg_proof", SszKZGProofSchema.INSTANCE),
+        namedSchema("column_index", SszPrimitiveSchemas.UINT64_SCHEMA),
+        namedSchema("row_index", SszPrimitiveSchemas.UINT64_SCHEMA));
+  }
+
+  public CellSchema getCellSchema() {
+    return (CellSchema) getFieldSchema0();
+  }
+
+  public MatrixEntry create(
+      final Cell cell, final KZGProof kzgProof, final UInt64 columnIndex, final UInt64 rowIndex) {
+    return new MatrixEntry(
+        this, cell, new SszKZGProof(kzgProof), SszUInt64.of(columnIndex), SszUInt64.of(rowIndex));
+  }
+
+  public MatrixEntry create(
+      final KZGCell cell, final KZGProof kzgProof, final int columnIndex, final int rowIndex) {
+    return new MatrixEntry(
+        this,
+        getCellSchema().create(cell.bytes()),
+        new SszKZGProof(kzgProof),
+        SszUInt64.of(UInt64.valueOf(columnIndex)),
+        SszUInt64.of(UInt64.valueOf(rowIndex)));
+  }
+
+  public static MatrixEntrySchema create(final CellSchema cellSchema) {
+    return new MatrixEntrySchema(cellSchema);
+  }
+
+  @Override
+  public MatrixEntry createFromBackingNode(TreeNode node) {
+    return new MatrixEntry(this, node);
+  }
+}

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsEip7594.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/schemas/SchemaDefinitionsEip7594.java
@@ -20,6 +20,7 @@ import tech.pegasys.teku.spec.config.SpecConfigEip7594;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.CellSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSchema;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecarSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.MatrixEntrySchema;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlockSchema;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainer;
 import tech.pegasys.teku.spec.datastructures.blocks.BlockContainerSchema;
@@ -78,6 +79,7 @@ public class SchemaDefinitionsEip7594 extends SchemaDefinitionsDeneb {
   private final CellSchema cellSchema;
   private final DataColumnSchema dataColumnSchema;
   private final DataColumnSidecarSchema dataColumnSidecarSchema;
+  private final MatrixEntrySchema matrixEntrySchema;
   private final DataColumnSidecarsByRootRequestMessageSchema
       dataColumnSidecarsByRootRequestMessageSchema;
   private final DataColumnSidecarsByRangeRequestMessage
@@ -137,6 +139,7 @@ public class SchemaDefinitionsEip7594 extends SchemaDefinitionsDeneb {
     this.dataColumnSidecarSchema =
         DataColumnSidecarSchema.create(
             SignedBeaconBlockHeader.SSZ_SCHEMA, dataColumnSchema, specConfig);
+    this.matrixEntrySchema = MatrixEntrySchema.create(cellSchema);
     this.dataColumnSidecarsByRootRequestMessageSchema =
         new DataColumnSidecarsByRootRequestMessageSchema(specConfig);
     this.dataColumnSidecarsByRangeRequestMessageSchema =
@@ -264,16 +267,20 @@ public class SchemaDefinitionsEip7594 extends SchemaDefinitionsDeneb {
     return Optional.of(this);
   }
 
-  public DataColumnSidecarSchema getDataColumnSidecarSchema() {
-    return dataColumnSidecarSchema;
+  public CellSchema getCellSchema() {
+    return cellSchema;
   }
 
   public DataColumnSchema getDataColumnSchema() {
     return dataColumnSchema;
   }
 
-  public CellSchema getCellSchema() {
-    return cellSchema;
+  public DataColumnSidecarSchema getDataColumnSidecarSchema() {
+    return dataColumnSidecarSchema;
+  }
+
+  public MatrixEntrySchema getMatrixEntrySchema() {
+    return matrixEntrySchema;
   }
 
   public DataColumnSidecarsByRootRequestMessageSchema

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -36,6 +36,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsEip7594;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolverStub;
 import tech.pegasys.teku.statetransition.datacolumns.ColumnSlotAndIdentifier;
@@ -53,6 +54,9 @@ public class RecoveringSidecarRetrieverTest {
       SpecConfigEip7594.required(spec.forMilestone(SpecMilestone.EIP7594).getConfig());
   final MiscHelpersEip7594 miscHelpers =
       MiscHelpersEip7594.required(spec.forMilestone(SpecMilestone.EIP7594).miscHelpers());
+  final SchemaDefinitionsEip7594 schemaDefinitions =
+      SchemaDefinitionsEip7594.required(
+          spec.forMilestone(SpecMilestone.EIP7594).getSchemaDefinitions());
   final int columnCount = config.getNumberOfColumns();
   final KZG kzg = KZG.getInstance(false);
 
@@ -82,6 +86,7 @@ public class RecoveringSidecarRetrieverTest {
             delegateRetriever,
             kzg,
             miscHelpers,
+            schemaDefinitions,
             blockResolver,
             db,
             stubAsyncRunner,

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -120,6 +120,7 @@ import tech.pegasys.teku.spec.logic.common.statetransition.results.BlockImportRe
 import tech.pegasys.teku.spec.logic.common.util.BlockRewardCalculatorUtil;
 import tech.pegasys.teku.spec.logic.versions.deneb.helpers.MiscHelpersDeneb;
 import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsEip7594;
 import tech.pegasys.teku.statetransition.EpochCachePrimer;
 import tech.pegasys.teku.statetransition.LocalOperationAcceptedFilter;
 import tech.pegasys.teku.statetransition.MappedOperationPool;
@@ -707,11 +708,15 @@ public class BeaconChainController extends Service implements BeaconChainControl
             Duration.ofSeconds(1));
     MiscHelpersEip7594 miscHelpersEip7594 =
         MiscHelpersEip7594.required(spec.forMilestone(SpecMilestone.EIP7594).miscHelpers());
+    SchemaDefinitionsEip7594 schemaDefinitionsEip7594 =
+        SchemaDefinitionsEip7594.required(
+            spec.forMilestone(SpecMilestone.EIP7594).getSchemaDefinitions());
     RecoveringSidecarRetriever recoveringSidecarRetriever =
         new RecoveringSidecarRetriever(
             sidecarRetriever,
             kzg,
             miscHelpersEip7594,
+            schemaDefinitionsEip7594,
             canonicalBlockResolver,
             sidecarDB,
             operationPoolAsyncRunner,


### PR DESCRIPTION
- reference tests bumped to `v1.5.0-alpha.3`. Passed all except 5 `recover_cells_and_kzg_proofs` tests, which we shouldn't fix, they will be removed in the next release, because `proofs` field shouldn't be used there with the spec update
- updated to the current spec which uses `MatrixEntry`
- kept parallelism in recovering

Fixes #68 