### PR TITLE
Publish recovered sidecars on gossip

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -53,6 +54,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   private final DataColumnSidecarDB sidecarDB;
   private final AsyncRunner asyncRunner;
   private final Duration recoverInitiationTimeout;
+  private final Consumer<DataColumnSidecar> dataColumnSidecarPublisher;
   private final int columnCount;
   private final int recoverColumnCount;
 
@@ -64,6 +66,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
       MiscHelpersEip7594 specHelpers,
       CanonicalBlockResolver blockResolver,
       DataColumnSidecarDB sidecarDB,
+      Consumer<DataColumnSidecar> dataColumnSidecarPublisher,
       AsyncRunner asyncRunner,
       Duration recoverInitiationTimeout,
       int columnCount) {
@@ -72,6 +75,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
     this.specHelpers = specHelpers;
     this.blockResolver = blockResolver;
     this.sidecarDB = sidecarDB;
+    this.dataColumnSidecarPublisher = dataColumnSidecarPublisher;
     this.asyncRunner = asyncRunner;
     this.recoverInitiationTimeout = recoverInitiationTimeout;
     this.columnCount = columnCount;
@@ -210,6 +214,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
       promisesByColIdx.forEach(
           (key, value) -> {
             DataColumnSidecar columnSidecar = existingSidecarsByColIdx.get(key);
+            dataColumnSidecarPublisher.accept(columnSidecar);
             value.forEach(promise -> promise.completeAsync(columnSidecar, asyncRunner));
           });
       promisesByColIdx.clear();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -16,8 +16,10 @@ package tech.pegasys.teku.statetransition.datacolumns.retriever;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -77,6 +79,8 @@ public class RecoveringSidecarRetrieverTest {
     int columnsInDbCount = 3;
 
     DataColumnSidecarRetrieverStub delegateRetriever = new DataColumnSidecarRetrieverStub();
+    final List<DataColumnSidecar> stubPublisherStorage = new ArrayList<>();
+    final Consumer<DataColumnSidecar> stubPublisher = sidecar -> stubPublisherStorage.add(sidecar);
     RecoveringSidecarRetriever recoverRetrievr =
         new RecoveringSidecarRetriever(
             delegateRetriever,
@@ -84,6 +88,7 @@ public class RecoveringSidecarRetrieverTest {
             miscHelpers,
             blockResolver,
             db,
+            stubPublisher,
             stubAsyncRunner,
             Duration.ofSeconds(1),
             128);
@@ -123,5 +128,6 @@ public class RecoveringSidecarRetrieverTest {
     assertThat(res0.get(1, TimeUnit.SECONDS)).isEqualTo(sidecars.get(0));
     assertThat(res1.get(1, TimeUnit.SECONDS)).isEqualTo(sidecars.get(1));
     assertThat(delegateRetriever.requests).allMatch(r -> r.promise().isDone());
+    assertThat(stubPublisherStorage).containsExactlyInAnyOrder(sidecars.get(0), sidecars.get(1));
   }
 }

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -714,6 +714,11 @@ public class BeaconChainController extends Service implements BeaconChainControl
             miscHelpersEip7594,
             canonicalBlockResolver,
             sidecarDB,
+            // avoids circular dependency
+            sidecar ->
+                eventChannels
+                    .getPublisher(DataColumnSidecarGossipChannel.class)
+                    .publishDataColumnSidecar(sidecar),
             operationPoolAsyncRunner,
             Duration.ofMinutes(5),
             configEip7594.getNumberOfColumns());


### PR DESCRIPTION
Addressing https://github.com/ethereum/consensus-specs/pull/3794
There is one issue in it: these sidecars will pass `onNewValidatedDataColumnSidecar(DataColumnSidecar dataColumnSidecar)` twice but I don't see any fatal consequences from this, though we could try to improve this in the future. Or maybe add comment to not forget.