### PR TITLE
Fix SimpleSidecarRetriever peer selection

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -27,6 +27,8 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -55,6 +57,13 @@ public class SimpleSidecarRetriever
   private final Duration roundPeriod;
   private final int maxRequestCount;
 
+  private final Map<ColumnSlotAndIdentifier, RetrieveRequest> pendingRequests =
+      new LinkedHashMap<>();
+  private final Map<UInt256, ConnectedPeer> connectedPeers = new HashMap<>();
+  private boolean started = false;
+  private AtomicLong retrieveCounter = new AtomicLong();
+  private AtomicLong errorCounter = new AtomicLong();
+
   public SimpleSidecarRetriever(
       Spec spec,
       DataColumnPeerManager peerManager,
@@ -74,13 +83,6 @@ public class SimpleSidecarRetriever
         SpecConfigEip7594.required(spec.forMilestone(SpecMilestone.EIP7594).getConfig())
             .getMaxRequestDataColumnSidecars();
   }
-
-  private final Map<ColumnSlotAndIdentifier, RetrieveRequest> pendingRequests =
-      new LinkedHashMap<>();
-  private final Map<UInt256, ConnectedPeer> connectedPeers = new HashMap<>();
-  private boolean started = false;
-  private AtomicLong retrieveCounter = new AtomicLong();
-  private AtomicLong errorCounter = new AtomicLong();
 
   private void startIfNecessary() {
     if (!started) {
@@ -124,10 +126,16 @@ public class SimpleSidecarRetriever
 
   private Optional<ConnectedPeer> findBestMatchingPeer(
       RetrieveRequest request, RequestTracker ongoingRequestsTracker) {
-    return findMatchingPeers(request, ongoingRequestsTracker).stream()
-        .max(
-            Comparator.comparing(
-                peer -> ongoingRequestsTracker.getAvailableRequestCount(peer.nodeId)));
+    Collection<ConnectedPeer> matchingPeers = findMatchingPeers(request, ongoingRequestsTracker);
+
+    // taking first the peers which were not requested yet, then peers which are less busy
+    Comparator<ConnectedPeer> comparator =
+        Comparator.comparing((ConnectedPeer peer) -> request.getPeerRequestCount(peer.nodeId))
+            .reversed()
+            .thenComparing(
+                (ConnectedPeer peer) ->
+                    ongoingRequestsTracker.getAvailableRequestCount(peer.nodeId));
+    return matchingPeers.stream().max(comparator);
   }
 
   private Collection<ConnectedPeer> findMatchingPeers(
@@ -159,6 +167,7 @@ public class SimpleSidecarRetriever
     for (RequestMatch match : matches) {
       SafeFuture<DataColumnSidecar> reqRespPromise =
           reqResp.requestDataColumnSidecar(match.peer.nodeId, match.request.columnId.identifier());
+      match.request().onPeerRequest(match.peer().nodeId);
       match.request.activeRpcRequest =
           new ActiveRequest(
               reqRespPromise.whenComplete(
@@ -240,6 +249,7 @@ public class SimpleSidecarRetriever
     final ColumnSlotAndIdentifier columnId;
     final DataColumnPeerSearcher.PeerSearchRequest peerSearchRequest;
     final SafeFuture<DataColumnSidecar> result = new SafeFuture<>();
+    final Map<UInt256, Integer> peerRequestCount = new HashMap<>();
     volatile ActiveRequest activeRpcRequest = null;
 
     private RetrieveRequest(
@@ -247,6 +257,14 @@ public class SimpleSidecarRetriever
         DataColumnPeerSearcher.PeerSearchRequest peerSearchRequest) {
       this.columnId = columnId;
       this.peerSearchRequest = peerSearchRequest;
+    }
+
+    public void onPeerRequest(UInt256 peerId) {
+      peerRequestCount.compute(peerId, (__, curCount) -> curCount == null ? 1 : curCount + 1);
+    }
+
+    public int getPeerRequestCount(UInt256 peerId) {
+      return peerRequestCount.getOrDefault(peerId, 0);
     }
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -27,8 +27,6 @@ import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
@@ -60,6 +60,7 @@ public class DataColumnSidecarCustodyImplTest {
         new DataColumnSidecarCustodyImpl(spec, blockResolver, db, myNodeId, subnetCount);
     BeaconBlock block = blockResolver.addBlock(10, true);
     DataColumnSidecar sidecar0 = createSidecar(block, 0);
+    DataColumnSidecar sidecar1 = createSidecar(block, 1);
     DataColumnIdentifier columnId0 = DataColumnIdentifier.createFromSidecar(sidecar0);
 
     SafeFuture<Optional<DataColumnSidecar>> fRet1 = custody.getCustodyDataColumnSidecar(columnId0);
@@ -67,27 +68,15 @@ public class DataColumnSidecarCustodyImplTest {
 
     assertThat(ret1).isEmpty();
 
+    custody.onNewValidatedDataColumnSidecar(sidecar1);
+    custody.onNewValidatedDataColumnSidecar(sidecar0);
+
     SafeFuture<Optional<DataColumnSidecar>> fRet2_1 =
         custody.getCustodyDataColumnSidecar(columnId0);
     SafeFuture<Optional<DataColumnSidecar>> fRet2_2 =
         custody.getCustodyDataColumnSidecar(columnId0);
 
-    custody.onNewValidatedDataColumnSidecar(sidecar0);
-
     assertThat(fRet2_1.get().get()).isEqualTo(sidecar0);
     assertThat(fRet2_2.get().get()).isEqualTo(sidecar0);
-
-    SafeFuture<Optional<DataColumnSidecar>> fRet3 = custody.getCustodyDataColumnSidecar(columnId0);
-
-    assertThat(fRet3.get().get()).isEqualTo(sidecar0);
-
-    DataColumnSidecar sidecar1 = createSidecar(block, 1);
-    DataColumnIdentifier columnId1 = DataColumnIdentifier.createFromSidecar(sidecar1);
-
-    SafeFuture<Optional<DataColumnSidecar>> fRet4 = custody.getCustodyDataColumnSidecar(columnId1);
-    assertThat(fRet4).isNotDone();
-
-    custody.onNewValidatedDataColumnSidecar(sidecar1);
-    assertThat(fRet4.get().get()).isEqualTo(sidecar1);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SampleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SampleSidecarRetrieverTest.java
@@ -200,5 +200,11 @@ public class SampleSidecarRetrieverTest {
     advanceTimeGradually(retrieverRound);
 
     assertThat(allRequestCountsFunc.get()).isEqualTo(List.of(0, 0, 2, 2));
+
+    overloadedCustodyPeer.currentRequestLimit(1);
+
+    advanceTimeGradually(retrieverRound);
+
+    assertThat(allRequestCountsFunc.get()).isEqualTo(List.of(0, 1, 2, 2));
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SampleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SampleSidecarRetrieverTest.java
@@ -16,13 +16,11 @@ package tech.pegasys.teku.statetransition.datacolumns.retriever;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
 import org.junit.jupiter.api.Test;

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeer.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeer.java
@@ -35,7 +35,7 @@ public class TestPeer {
 
   private final Map<DataColumnIdentifier, DataColumnSidecar> availableSidecars = new HashMap<>();
   private final List<Request> requests = new ArrayList<>();
-  private int currentRequestLimit = 0;
+  private int currentRequestLimit = 1000;
 
   public TestPeer(AsyncRunner asyncRunner, UInt256 nodeId, Duration latency) {
     this.asyncRunner = asyncRunner;

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeer.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/TestPeer.java
@@ -90,7 +90,8 @@ public class TestPeer {
     return currentRequestLimit;
   }
 
-  public void setCurrentRequestLimit(int currentRequestLimit) {
+  public TestPeer currentRequestLimit(int currentRequestLimit) {
     this.currentRequestLimit = currentRequestLimit;
+    return this;
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

When selecting the best peer to request a column we need to deprioritize those peers which already failed to return this column.

Alter the old test and add a new one 

Also piggy tailing the test fix: Fix failing DataColumnSidecarCustodyImplTest as it was basically testing long poll functionality which is now in a separate class.