### PR TITLE
Add DB auto-pruning class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.swp
 *.log
 .lh/*
-db/
+/db/
 db.version
 .classpath
 .DS_Store

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -31,6 +31,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIde
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 
 public class DasSamplerBasic
@@ -42,11 +43,11 @@ public class DasSamplerBasic
   private final DataColumnSidecarCustody custody;
 
   private final Spec spec;
-  private final DataColumnSidecarDB db;
+  private final DataColumnSidecarDbAccessor db;
 
   public DasSamplerBasic(
       final Spec spec,
-      final DataColumnSidecarDB db,
+      final DataColumnSidecarDbAccessor db,
       final DataColumnSidecarCustody custody,
       final UInt256 nodeId,
       final int totalCustodySubnetCount) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSi
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 
 public class DasSamplerBasic

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasSamplerBasic.java
@@ -30,7 +30,6 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSi
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
-import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -227,8 +227,8 @@ public class DataColumnSidecarCustodyImpl
   private SafeFuture<SlotCustody> retrieveSlotCustody(final UInt64 slot) {
     final SafeFuture<Optional<Bytes32>> maybeCanonicalBlockRoot = getBlockRootIfHaveBlobs(slot);
     final List<UInt64> requiredColumns = getCustodyColumnsForSlot(slot);
-    final SafeFuture<Stream<DataColumnIdentifier>> existingColumns =
-        db.streamColumnIdentifiers(slot);
+    final SafeFuture<List<DataColumnIdentifier>> existingColumns =
+        db.getColumnIdentifiers(slot);
     return SafeFuture.allOf(maybeCanonicalBlockRoot, existingColumns)
         .thenApply(
             __ ->
@@ -236,7 +236,7 @@ public class DataColumnSidecarCustodyImpl
                     slot,
                     maybeCanonicalBlockRoot.getImmediately(),
                     requiredColumns,
-                    existingColumns.getImmediately().toList()));
+                    existingColumns.getImmediately()));
   }
 
   private SafeFuture<Optional<Bytes32>> getBlockRootIfHaveBlobs(UInt64 slot) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -38,6 +38,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIde
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.util.ColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 
 public class DataColumnSidecarCustodyImpl

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -97,20 +97,21 @@ public class DataColumnSidecarCustodyImpl
       Spec spec,
       CanonicalBlockResolver blockResolver,
       DataColumnSidecarDbAccessor db,
+      MinCustodyPeriodSlotCalculator minCustodyPeriodSlotCalculator,
       UInt256 nodeId,
       int totalCustodySubnetCount) {
-
     checkNotNull(spec);
     checkNotNull(blockResolver);
+    checkNotNull(minCustodyPeriodSlotCalculator);
     checkNotNull(db);
     checkNotNull(nodeId);
 
     this.spec = spec;
     this.db = db;
     this.blockResolver = blockResolver;
+    this.minCustodyPeriodSlotCalculator = minCustodyPeriodSlotCalculator;
     this.nodeId = nodeId;
     this.totalCustodySubnetCount = totalCustodySubnetCount;
-    this.minCustodyPeriodSlotCalculator = MinCustodyPeriodSlotCalculator.createFromSpec(spec);
     this.knownSavedIdentifiers =
         LimitedMap.createSynchronizedNatural(
             VALID_BLOCK_SET_SIZE * spec.getNumberOfDataColumns().orElseThrow());

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -31,14 +31,12 @@ import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
 import tech.pegasys.teku.infrastructure.collections.LimitedMap;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.spec.SpecMilestone;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.datastructures.util.ColumnSlotAndIdentifier;
 import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
-import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/MinCustodyPeriodSlotCalculator.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.datacolumns;
+
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.config.NetworkingSpecConfigEip7594;
+
+public interface MinCustodyPeriodSlotCalculator {
+
+  static MinCustodyPeriodSlotCalculator createFromSpec(Spec spec) {
+    return currentSlot -> {
+      UInt64 currentEpoch = spec.computeEpochAtSlot(currentSlot);
+      int custodyPeriodEpochs =
+          spec.getSpecConfig(currentEpoch)
+              .toVersionEip7594()
+              .map(NetworkingSpecConfigEip7594::getMinEpochsForDataColumnSidecarsRequests)
+              .orElse(0);
+      if (custodyPeriodEpochs == 0) {
+        return currentSlot;
+      } else {
+        UInt64 minCustodyEpoch = currentEpoch.minusMinZero(custodyPeriodEpochs);
+        return spec.computeStartSlotAtEpoch(minCustodyEpoch);
+      }
+    };
+  }
+
+  UInt64 getMinCustodyPeriodSlot(UInt64 currentSlot);
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/AbstractDelegatingDasDb.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/AbstractDelegatingDasDb.java
@@ -21,40 +21,31 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.datastructures.util.ColumnSlotAndIdentifier;
-import tech.pegasys.teku.storage.api.SidecarUpdateChannel;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
-public interface DataColumnSidecarDB extends DataColumnSidecarCoreDB {
+abstract class AbstractDelegatingDasDb implements DataColumnSidecarCoreDB {
+  private final DataColumnSidecarCoreDB delegateDb;
 
-  static DataColumnSidecarDB create(
-      final CombinedChainDataClient combinedChainDataClient,
-      final SidecarUpdateChannel sidecarUpdateChannel) {
-    return new DataColumnSidecarDBImpl(combinedChainDataClient, sidecarUpdateChannel);
+  public AbstractDelegatingDasDb(DataColumnSidecarDB delegateDb) {
+    this.delegateDb = delegateDb;
   }
 
-  // read
-
-  SafeFuture<Optional<UInt64>> getFirstCustodyIncompleteSlot();
-
-  SafeFuture<Optional<UInt64>> getFirstSamplerIncompleteSlot();
+  @Override
+  public SafeFuture<Optional<DataColumnSidecar>> getSidecar(DataColumnIdentifier identifier) {
+    return delegateDb.getSidecar(identifier);
+  }
 
   @Override
-  SafeFuture<Optional<DataColumnSidecar>> getSidecar(DataColumnIdentifier identifier);
+  public SafeFuture<Optional<DataColumnSidecar>> getSidecar(ColumnSlotAndIdentifier identifier) {
+    return delegateDb.getSidecar(identifier);
+  }
 
   @Override
-  SafeFuture<Optional<DataColumnSidecar>> getSidecar(ColumnSlotAndIdentifier identifier);
+  public SafeFuture<List<DataColumnIdentifier>> getColumnIdentifiers(UInt64 slot) {
+    return delegateDb.getColumnIdentifiers(slot);
+  }
 
   @Override
-  SafeFuture<List<DataColumnIdentifier>> getColumnIdentifiers(UInt64 slot);
-
-  // update
-
-  SafeFuture<Void> setFirstCustodyIncompleteSlot(UInt64 slot);
-
-  SafeFuture<Void> setFirstSamplerIncompleteSlot(UInt64 slot);
-
-  @Override
-  void addSidecar(DataColumnSidecar sidecar);
-
-  void pruneAllSidecars(UInt64 tillSlot);
+  public void addSidecar(DataColumnSidecar sidecar) {
+    delegateDb.addSidecar(sidecar);
+  }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/AbstractDelegatingDasDb.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/AbstractDelegatingDasDb.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.statetransition.datacolumns.db;
 
 import java.util.List;
 import java.util.Optional;
-
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/AutoPruningDasDb.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/AutoPruningDasDb.java
@@ -13,15 +13,14 @@
 
 package tech.pegasys.teku.statetransition.datacolumns.db;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 import tech.pegasys.teku.statetransition.datacolumns.MinCustodyPeriodSlotCalculator;
-
-import java.util.Optional;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 class AutoPruningDasDb extends AbstractDelegatingDasDb implements DataColumnSidecarDbAccessor {
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/AutoPruningDasDb.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/AutoPruningDasDb.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.datacolumns.db;
+
+import com.google.common.base.Preconditions;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
+import tech.pegasys.teku.statetransition.datacolumns.MinCustodyPeriodSlotCalculator;
+
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+class AutoPruningDasDb extends AbstractDelegatingDasDb implements DataColumnSidecarDbAccessor {
+
+  private final MinCustodyPeriodSlotCalculator minCustodyPeriodSlotCalculator;
+  private volatile UInt64 maxSidecarSlot = UInt64.ZERO;
+  private final DataColumnSidecarDB delegate;
+  private final int marginPruneSlots;
+
+  public AutoPruningDasDb(
+      DataColumnSidecarDB delegate,
+      MinCustodyPeriodSlotCalculator minCustodyPeriodSlotCalculator,
+      int marginPruneSlots) {
+    super(delegate);
+    this.delegate = checkNotNull(delegate);
+    this.minCustodyPeriodSlotCalculator = checkNotNull(minCustodyPeriodSlotCalculator);
+    this.marginPruneSlots = marginPruneSlots;
+  }
+
+  private UInt64 calculatePruneSlot(UInt64 currentSlot) {
+    return minCustodyPeriodSlotCalculator
+        .getMinCustodyPeriodSlot(currentSlot)
+        .minusMinZero(marginPruneSlots);
+  }
+
+  @Override
+  public void addSidecar(DataColumnSidecar sidecar) {
+    super.addSidecar(sidecar);
+    if (sidecar.getSlot().isGreaterThan(maxSidecarSlot)) {
+      maxSidecarSlot = sidecar.getSlot();
+      UInt64 minCustodySlot = calculatePruneSlot(maxSidecarSlot);
+      delegate.pruneAllSidecars(minCustodySlot);
+    }
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getFirstCustodyIncompleteSlot() {
+    return delegate.getFirstCustodyIncompleteSlot();
+  }
+
+  @Override
+  public SafeFuture<Optional<UInt64>> getFirstSamplerIncompleteSlot() {
+    return delegate.getFirstSamplerIncompleteSlot();
+  }
+
+  @Override
+  public SafeFuture<Void> setFirstCustodyIncompleteSlot(UInt64 slot) {
+    return delegate.setFirstCustodyIncompleteSlot(slot);
+  }
+
+  @Override
+  public SafeFuture<Void> setFirstSamplerIncompleteSlot(UInt64 slot) {
+    return delegate.setFirstSamplerIncompleteSlot(slot);
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarCoreDB.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarCoreDB.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.statetransition.datacolumns.db;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
@@ -34,5 +33,4 @@ interface DataColumnSidecarCoreDB {
 
   // update
   void addSidecar(DataColumnSidecar sidecar);
-
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarCoreDB.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarCoreDB.java
@@ -15,46 +15,24 @@ package tech.pegasys.teku.statetransition.datacolumns.db;
 
 import java.util.List;
 import java.util.Optional;
-
+import java.util.stream.Stream;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.datastructures.util.ColumnSlotAndIdentifier;
-import tech.pegasys.teku.storage.api.SidecarUpdateChannel;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
-public interface DataColumnSidecarDB extends DataColumnSidecarCoreDB {
-
-  static DataColumnSidecarDB create(
-      final CombinedChainDataClient combinedChainDataClient,
-      final SidecarUpdateChannel sidecarUpdateChannel) {
-    return new DataColumnSidecarDBImpl(combinedChainDataClient, sidecarUpdateChannel);
-  }
+interface DataColumnSidecarCoreDB {
 
   // read
 
-  SafeFuture<Optional<UInt64>> getFirstCustodyIncompleteSlot();
-
-  SafeFuture<Optional<UInt64>> getFirstSamplerIncompleteSlot();
-
-  @Override
   SafeFuture<Optional<DataColumnSidecar>> getSidecar(DataColumnIdentifier identifier);
 
-  @Override
   SafeFuture<Optional<DataColumnSidecar>> getSidecar(ColumnSlotAndIdentifier identifier);
 
-  @Override
   SafeFuture<List<DataColumnIdentifier>> getColumnIdentifiers(UInt64 slot);
 
   // update
-
-  SafeFuture<Void> setFirstCustodyIncompleteSlot(UInt64 slot);
-
-  SafeFuture<Void> setFirstSamplerIncompleteSlot(UInt64 slot);
-
-  @Override
   void addSidecar(DataColumnSidecar sidecar);
 
-  void pruneAllSidecars(UInt64 tillSlot);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.statetransition.datacolumns;
+package tech.pegasys.teku.statetransition.datacolumns.db;
 
 import java.util.Optional;
 import java.util.stream.Stream;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
@@ -13,8 +13,9 @@
 
 package tech.pegasys.teku.statetransition.datacolumns.db;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.stream.Stream;
+
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
@@ -33,7 +34,7 @@ public interface DataColumnSidecarDB {
 
   SafeFuture<Optional<DataColumnSidecar>> getSidecar(ColumnSlotAndIdentifier identifier);
 
-  SafeFuture<Stream<DataColumnIdentifier>> streamColumnIdentifiers(UInt64 slot);
+  SafeFuture<List<DataColumnIdentifier>> getColumnIdentifiers(UInt64 slot);
 
   // update
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.statetransition.datacolumns.db;
 
 import java.util.List;
 import java.util.Optional;
-
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
@@ -29,8 +29,7 @@ import tech.pegasys.teku.spec.datastructures.util.ColumnSlotAndIdentifier;
 import tech.pegasys.teku.storage.api.SidecarUpdateChannel;
 import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
-// FIXME: remove stinky joins
-public class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
+class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
   private static final Logger LOG = LogManager.getLogger("das-nyota");
 
   private final CombinedChainDataClient combinedChainDataClient;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
@@ -14,11 +14,9 @@
 package tech.pegasys.teku.statetransition.datacolumns.db;
 
 import it.unimi.dsi.fastutil.Pair;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -69,7 +67,8 @@ class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
   public SafeFuture<List<DataColumnIdentifier>> getColumnIdentifiers(final UInt64 slot) {
     return combinedChainDataClient
         .getDataColumnIdentifiers(slot)
-        .thenApply(identifiers -> identifiers.stream().map(ColumnSlotAndIdentifier::identifier).toList());
+        .thenApply(
+            identifiers -> identifiers.stream().map(ColumnSlotAndIdentifier::identifier).toList());
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.statetransition.datacolumns;
+package tech.pegasys.teku.statetransition.datacolumns.db;
 
 import it.unimi.dsi.fastutil.Pair;
 import java.util.Optional;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
@@ -14,9 +14,11 @@
 package tech.pegasys.teku.statetransition.datacolumns.db;
 
 import it.unimi.dsi.fastutil.Pair;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
@@ -65,10 +67,10 @@ public class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
   }
 
   @Override
-  public SafeFuture<Stream<DataColumnIdentifier>> streamColumnIdentifiers(final UInt64 slot) {
+  public SafeFuture<List<DataColumnIdentifier>> getColumnIdentifiers(final UInt64 slot) {
     return combinedChainDataClient
         .getDataColumnIdentifiers(slot)
-        .thenApply(identifiers -> identifiers.stream().map(ColumnSlotAndIdentifier::identifier));
+        .thenApply(identifiers -> identifiers.stream().map(ColumnSlotAndIdentifier::identifier).toList());
   }
 
   @Override
@@ -79,17 +81,17 @@ public class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
               sidecarUpdateChannel.onFirstCustodyIncompleteSlot(slot);
               if (maybeFirstIncompleteSlot.isEmpty()
                   || !maybeFirstIncompleteSlot.get().equals(slot)) {
-                streamColumnIdentifiers(slot)
+                getColumnIdentifiers(slot)
                     .thenCompose(
                         newSlotColumnIdentifiers -> {
-                          final long newSlotCount = newSlotColumnIdentifiers.count();
+                          final long newSlotCount = newSlotColumnIdentifiers.size();
                           if (maybeFirstIncompleteSlot.isEmpty()) {
                             return SafeFuture.completedFuture(Pair.of(0L, newSlotCount));
                           } else {
-                            return streamColumnIdentifiers(maybeFirstIncompleteSlot.get())
+                            return getColumnIdentifiers(maybeFirstIncompleteSlot.get())
                                 .thenApply(
                                     dataColumnIdentifierStream ->
-                                        Pair.of(dataColumnIdentifierStream.count(), newSlotCount));
+                                        Pair.of(dataColumnIdentifierStream.size(), newSlotCount));
                           }
                         })
                     .thenPeek(
@@ -129,10 +131,10 @@ public class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
     synchronized (this) {
       if (slot > maxAddedSlot) {
         final SafeFuture<UInt64> prevSlotCount =
-            streamColumnIdentifiers(UInt64.valueOf(maxAddedSlot))
+            getColumnIdentifiers(UInt64.valueOf(maxAddedSlot))
                 .thenApply(
                     dataColumnIdentifierStream ->
-                        UInt64.valueOf(dataColumnIdentifierStream.count()));
+                        UInt64.valueOf(dataColumnIdentifierStream.size()));
         final SafeFuture<UInt64> finalizedSlot =
             getFirstCustodyIncompleteSlot()
                 .thenApply(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessor.java
@@ -13,18 +13,12 @@
 
 package tech.pegasys.teku.statetransition.datacolumns.db;
 
-import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
-import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
-import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
-import tech.pegasys.teku.spec.datastructures.util.ColumnSlotAndIdentifier;
 
 /** Higher level {@link DataColumnSidecarDB} accessor */
-public interface DataColumnSidecarDbAccessor extends DataColumnSidecarCoreDB{
+public interface DataColumnSidecarDbAccessor extends DataColumnSidecarCoreDB {
 
   static DataColumnSidecarDbAccessorBuilder builder(DataColumnSidecarDB db) {
     return new DataColumnSidecarDbAccessorBuilder(db);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessor.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessor.java
@@ -15,46 +15,27 @@ package tech.pegasys.teku.statetransition.datacolumns.db;
 
 import java.util.List;
 import java.util.Optional;
-
+import java.util.Set;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.datastructures.util.ColumnSlotAndIdentifier;
-import tech.pegasys.teku.storage.api.SidecarUpdateChannel;
-import tech.pegasys.teku.storage.client.CombinedChainDataClient;
 
-public interface DataColumnSidecarDB extends DataColumnSidecarCoreDB {
+/** Higher level {@link DataColumnSidecarDB} accessor */
+public interface DataColumnSidecarDbAccessor extends DataColumnSidecarCoreDB{
 
-  static DataColumnSidecarDB create(
-      final CombinedChainDataClient combinedChainDataClient,
-      final SidecarUpdateChannel sidecarUpdateChannel) {
-    return new DataColumnSidecarDBImpl(combinedChainDataClient, sidecarUpdateChannel);
+  static DataColumnSidecarDbAccessorBuilder builder(DataColumnSidecarDB db) {
+    return new DataColumnSidecarDbAccessorBuilder(db);
   }
-
-  // read
 
   SafeFuture<Optional<UInt64>> getFirstCustodyIncompleteSlot();
 
   SafeFuture<Optional<UInt64>> getFirstSamplerIncompleteSlot();
 
-  @Override
-  SafeFuture<Optional<DataColumnSidecar>> getSidecar(DataColumnIdentifier identifier);
-
-  @Override
-  SafeFuture<Optional<DataColumnSidecar>> getSidecar(ColumnSlotAndIdentifier identifier);
-
-  @Override
-  SafeFuture<List<DataColumnIdentifier>> getColumnIdentifiers(UInt64 slot);
-
   // update
-
   SafeFuture<Void> setFirstCustodyIncompleteSlot(UInt64 slot);
 
   SafeFuture<Void> setFirstSamplerIncompleteSlot(UInt64 slot);
-
-  @Override
-  void addSidecar(DataColumnSidecar sidecar);
-
-  void pruneAllSidecars(UInt64 tillSlot);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessorBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessorBuilder.java
@@ -48,6 +48,7 @@ public class DataColumnSidecarDbAccessorBuilder {
 
   public class AutoPruneDbBuilder {
     private int pruneMarginSlots = 0;
+    private int prunePeriodInSlots = 1;
 
     /**
      * Additional period in slots to retain data column sidecars in DB before pruning
@@ -57,8 +58,16 @@ public class DataColumnSidecarDbAccessorBuilder {
       return this;
     }
 
+    /**
+     * Specifies how often (in slots) the db prune will be performed
+     * 1 means that the prune is to be called every slot
+     */
+    public void prunePeriodSlots(int prunePeriodInSlots) {
+      this.prunePeriodInSlots = prunePeriodInSlots;
+    }
+
     AutoPruningDasDb build() {
-      return new AutoPruningDasDb(db, getMinCustodyPeriodSlotCalculator(), pruneMarginSlots);
+      return new AutoPruningDasDb(db, getMinCustodyPeriodSlotCalculator(), pruneMarginSlots, prunePeriodInSlots);
     }
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessorBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessorBuilder.java
@@ -1,0 +1,64 @@
+package tech.pegasys.teku.statetransition.datacolumns.db;
+
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.statetransition.datacolumns.MinCustodyPeriodSlotCalculator;
+
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public class DataColumnSidecarDbAccessorBuilder {
+
+  private final DataColumnSidecarDB db;
+  private Spec spec;
+  private MinCustodyPeriodSlotCalculator minCustodyPeriodSlotCalculator;
+  private final AutoPruneDbBuilder autoPruneDbBuilder = new AutoPruneDbBuilder();
+
+
+  DataColumnSidecarDbAccessorBuilder(DataColumnSidecarDB db) {
+    this.db = db;
+  }
+
+  public DataColumnSidecarDbAccessorBuilder spec(Spec spec) {
+    this.spec = spec;
+    return this;
+  }
+
+  public DataColumnSidecarDbAccessorBuilder minCustodyPeriodSlotCalculator(MinCustodyPeriodSlotCalculator minCustodyPeriodSlotCalculator) {
+    this.minCustodyPeriodSlotCalculator = minCustodyPeriodSlotCalculator;
+    return this;
+  }
+
+  public DataColumnSidecarDbAccessorBuilder withAutoPrune(Consumer<AutoPruneDbBuilder> builderConsumer) {
+    builderConsumer.accept(this.autoPruneDbBuilder);
+    return this;
+  }
+
+  public DataColumnSidecarDbAccessor build() {
+    return autoPruneDbBuilder.build();
+  }
+
+  MinCustodyPeriodSlotCalculator getMinCustodyPeriodSlotCalculator() {
+    if (minCustodyPeriodSlotCalculator == null) {
+      checkNotNull(spec);
+      minCustodyPeriodSlotCalculator = MinCustodyPeriodSlotCalculator.createFromSpec(spec);
+    }
+    return minCustodyPeriodSlotCalculator;
+  }
+
+  public class AutoPruneDbBuilder {
+    private int pruneMarginSlots = 0;
+
+    /**
+     * Additional period in slots to retain data column sidecars in DB before pruning
+     */
+    public AutoPruneDbBuilder pruneMarginSlots(int pruneMarginSlots) {
+      this.pruneMarginSlots = pruneMarginSlots;
+      return this;
+    }
+
+    AutoPruningDasDb build() {
+      return new AutoPruningDasDb(db, getMinCustodyPeriodSlotCalculator(), pruneMarginSlots);
+    }
+  }
+}

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessorBuilder.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDbAccessorBuilder.java
@@ -1,11 +1,23 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.statetransition.datacolumns.db;
 
-import tech.pegasys.teku.spec.Spec;
-import tech.pegasys.teku.statetransition.datacolumns.MinCustodyPeriodSlotCalculator;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.function.Consumer;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.statetransition.datacolumns.MinCustodyPeriodSlotCalculator;
 
 public class DataColumnSidecarDbAccessorBuilder {
 
@@ -13,7 +25,6 @@ public class DataColumnSidecarDbAccessorBuilder {
   private Spec spec;
   private MinCustodyPeriodSlotCalculator minCustodyPeriodSlotCalculator;
   private final AutoPruneDbBuilder autoPruneDbBuilder = new AutoPruneDbBuilder();
-
 
   DataColumnSidecarDbAccessorBuilder(DataColumnSidecarDB db) {
     this.db = db;
@@ -24,12 +35,14 @@ public class DataColumnSidecarDbAccessorBuilder {
     return this;
   }
 
-  public DataColumnSidecarDbAccessorBuilder minCustodyPeriodSlotCalculator(MinCustodyPeriodSlotCalculator minCustodyPeriodSlotCalculator) {
+  public DataColumnSidecarDbAccessorBuilder minCustodyPeriodSlotCalculator(
+      MinCustodyPeriodSlotCalculator minCustodyPeriodSlotCalculator) {
     this.minCustodyPeriodSlotCalculator = minCustodyPeriodSlotCalculator;
     return this;
   }
 
-  public DataColumnSidecarDbAccessorBuilder withAutoPrune(Consumer<AutoPruneDbBuilder> builderConsumer) {
+  public DataColumnSidecarDbAccessorBuilder withAutoPrune(
+      Consumer<AutoPruneDbBuilder> builderConsumer) {
     builderConsumer.accept(this.autoPruneDbBuilder);
     return this;
   }
@@ -50,24 +63,23 @@ public class DataColumnSidecarDbAccessorBuilder {
     private int pruneMarginSlots = 0;
     private int prunePeriodInSlots = 1;
 
-    /**
-     * Additional period in slots to retain data column sidecars in DB before pruning
-     */
+    /** Additional period in slots to retain data column sidecars in DB before pruning */
     public AutoPruneDbBuilder pruneMarginSlots(int pruneMarginSlots) {
       this.pruneMarginSlots = pruneMarginSlots;
       return this;
     }
 
     /**
-     * Specifies how often (in slots) the db prune will be performed
-     * 1 means that the prune is to be called every slot
+     * Specifies how often (in slots) the db prune will be performed 1 means that the prune is to be
+     * called every slot
      */
     public void prunePeriodSlots(int prunePeriodInSlots) {
       this.prunePeriodInSlots = prunePeriodInSlots;
     }
 
     AutoPruningDasDb build() {
-      return new AutoPruningDasDb(db, getMinCustodyPeriodSlotCalculator(), pruneMarginSlots, prunePeriodInSlots);
+      return new AutoPruningDasDb(
+          db, getMinCustodyPeriodSlotCalculator(), pruneMarginSlots, prunePeriodInSlots);
     }
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -143,11 +143,11 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
         recoveryEntry.block.getSlot(),
         recoveryEntry.block.getRoot());
     sidecarDB
-        .streamColumnIdentifiers(block.getSlot())
+        .getColumnIdentifiers(block.getSlot())
         .thenCompose(
             dataColumnIdentifiers ->
                 SafeFuture.collectAll(
-                    dataColumnIdentifiers.limit(recoverColumnCount).map(sidecarDB::getSidecar)))
+                    dataColumnIdentifiers.stream().limit(recoverColumnCount).map(sidecarDB::getSidecar)))
         .thenPeek(
             maybeDataColumnSidecars -> {
               maybeDataColumnSidecars.forEach(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -40,6 +40,7 @@ import tech.pegasys.teku.spec.schemas.SchemaDefinitionsEip7594;
 import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolver;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSlotAndIdentifier;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
 public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   private static final Logger LOG = LogManager.getLogger("das-nyota");
@@ -49,7 +50,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
   private final MiscHelpersEip7594 specHelpers;
   private final SchemaDefinitionsEip7594 schemaDefinitions;
   private final CanonicalBlockResolver blockResolver;
-  private final DataColumnSidecarDB sidecarDB;
+  private final DataColumnSidecarDbAccessor sidecarDB;
   private final AsyncRunner asyncRunner;
   private final Duration recoverInitiationTimeout;
   private final int columnCount;
@@ -63,7 +64,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
       MiscHelpersEip7594 specHelpers,
       SchemaDefinitionsEip7594 schemaDefinitionsEip7594,
       CanonicalBlockResolver blockResolver,
-      DataColumnSidecarDB sidecarDB,
+      DataColumnSidecarDbAccessor sidecarDB,
       AsyncRunner asyncRunner,
       Duration recoverInitiationTimeout,
       int columnCount) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -38,7 +38,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIde
 import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsEip7594;
 import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolver;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarDB;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSlotAndIdentifier;
 
 public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -38,7 +38,6 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIde
 import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsEip7594;
 import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolver;
-import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSlotAndIdentifier;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
@@ -148,7 +147,9 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
         .thenCompose(
             dataColumnIdentifiers ->
                 SafeFuture.collectAll(
-                    dataColumnIdentifiers.stream().limit(recoverColumnCount).map(sidecarDB::getSidecar)))
+                    dataColumnIdentifiers.stream()
+                        .limit(recoverColumnCount)
+                        .map(sidecarDB::getSidecar)))
         .thenPeek(
             maybeDataColumnSidecars -> {
               maybeDataColumnSidecars.forEach(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
@@ -34,6 +34,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
 @SuppressWarnings("JavaCase")
 public class DasLongPollCustodyTest {
@@ -42,6 +43,8 @@ public class DasLongPollCustodyTest {
 
   final Spec spec = TestSpecFactory.createMinimalEip7594();
   final DataColumnSidecarDB db = new DataColumnSidecarDBStub();
+  final DataColumnSidecarDbAccessor dbAccessor =
+      DataColumnSidecarDbAccessor.builder(db).spec(spec).build();
   final CanonicalBlockResolverStub blockResolver = new CanonicalBlockResolverStub(spec);
   final UInt256 myNodeId = UInt256.ONE;
 
@@ -50,7 +53,7 @@ public class DasLongPollCustodyTest {
   final int subnetCount = config.getDataColumnSidecarSubnetCount();
 
   final DataColumnSidecarCustodyImpl custodyImpl =
-      new DataColumnSidecarCustodyImpl(spec, blockResolver, db, myNodeId, subnetCount);
+      new DataColumnSidecarCustodyImpl(spec, blockResolver, dbAccessor, myNodeId, subnetCount);
 
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(0, spec);
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 
 @SuppressWarnings("JavaCase")
 public class DasLongPollCustodyTest {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
@@ -31,11 +31,14 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
 public class DataColumnSidecarCustodyImplTest {
 
   final Spec spec = TestSpecFactory.createMinimalEip7594();
   final DataColumnSidecarDB db = new DataColumnSidecarDBStub();
+  final DataColumnSidecarDbAccessor dbAccessor =
+      DataColumnSidecarDbAccessor.builder(db).spec(spec).build();
   final CanonicalBlockResolverStub blockResolver = new CanonicalBlockResolverStub(spec);
   final UInt256 myNodeId = UInt256.ONE;
 
@@ -58,7 +61,7 @@ public class DataColumnSidecarCustodyImplTest {
   @SuppressWarnings("JavaCase")
   void sanityTest() throws Throwable {
     DataColumnSidecarCustodyImpl custody =
-        new DataColumnSidecarCustodyImpl(spec, blockResolver, db, myNodeId, subnetCount);
+        new DataColumnSidecarCustodyImpl(spec, blockResolver, dbAccessor, myNodeId, subnetCount);
     BeaconBlock block = blockResolver.addBlock(10, true);
     DataColumnSidecar sidecar0 = createSidecar(block, 0);
     DataColumnSidecar sidecar1 = createSidecar(block, 1);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 
 public class DataColumnSidecarCustodyImplTest {
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/db/AutoPruningDasDbTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/db/AutoPruningDasDbTest.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.statetransition.datacolumns.db;
 
-import org.assertj.core.api.Assertions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.TestSpecFactory;
@@ -9,11 +25,6 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.statetransition.datacolumns.DasCustodyStand;
 import tech.pegasys.teku.statetransition.datacolumns.MinCustodyPeriodSlotCalculator;
-
-import java.util.List;
-import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class AutoPruningDasDbTest {
   final Spec spec = TestSpecFactory.createMinimalEip7594();
@@ -83,8 +94,7 @@ public class AutoPruningDasDbTest {
           for (int slot = 0; slot < noDataTill; slot++) {
             assertThat(das.db.getSidecar(sidecarIds.get(slot)).join()).isEmpty();
           }
-          int existDataFrom =
-              sidecar.getSlot().minusMinZero(totalPeriod).intValue();
+          int existDataFrom = sidecar.getSlot().minusMinZero(totalPeriod).intValue();
           for (int slot = existDataFrom; slot <= sidecar.getSlot().intValue(); slot++) {
             assertThat(das.db.getSidecar(sidecarIds.get(slot)).join()).isNotEmpty();
           }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -39,9 +39,9 @@ import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsEip7594;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolverStub;
-import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarDBStub;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSlotAndIdentifier;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
 public class RecoveringSidecarRetrieverTest {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -39,7 +39,7 @@ import tech.pegasys.teku.spec.logic.versions.eip7594.helpers.MiscHelpersEip7594;
 import tech.pegasys.teku.spec.schemas.SchemaDefinitionsEip7594;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolverStub;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarDB;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarDBStub;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSlotAndIdentifier;
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -42,12 +42,15 @@ import tech.pegasys.teku.statetransition.datacolumns.CanonicalBlockResolverStub;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarDBStub;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSlotAndIdentifier;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
 public class RecoveringSidecarRetrieverTest {
 
   final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner();
   final Spec spec = TestSpecFactory.createMinimalEip7594();
   final DataColumnSidecarDB db = new DataColumnSidecarDBStub();
+  final DataColumnSidecarDbAccessor dbAccessor =
+      DataColumnSidecarDbAccessor.builder(db).spec(spec).build();
   final CanonicalBlockResolverStub blockResolver = new CanonicalBlockResolverStub(spec);
 
   final SpecConfigEip7594 config =
@@ -88,7 +91,7 @@ public class RecoveringSidecarRetrieverTest {
             miscHelpers,
             schemaDefinitions,
             blockResolver,
-            db,
+            dbAccessor,
             stubAsyncRunner,
             Duration.ofSeconds(1),
             128);

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
@@ -62,7 +62,6 @@ public class DasCustodyStand {
   private final List<FinalizedCheckpointChannel> finalizedListeners = new CopyOnWriteArrayList<>();
   private final int totalCustodySubnetCount;
 
-
   private UInt64 currentSlot = UInt64.ZERO;
 
   public DasCustodyStand(

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
@@ -26,7 +26,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
-
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
@@ -30,6 +30,7 @@ import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 import tech.pegasys.teku.spec.datastructures.util.ColumnSlotAndIdentifier;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 
 public class DataColumnSidecarDBStub implements DataColumnSidecarDB {
 

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
@@ -97,6 +97,7 @@ public class DataColumnSidecarDBStub implements DataColumnSidecarDB {
 
   @Override
   public void pruneAllSidecars(UInt64 tillSlot) {
+    dbWriteCounter.incrementAndGet();
     SortedMap<UInt64, Set<DataColumnIdentifier>> slotsToPrune = slotIds.headMap(tillSlot);
     slotsToPrune.values().stream().flatMap(Collection::stream).forEach(db::remove);
     slotsToPrune.clear();

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
@@ -13,10 +13,12 @@
 
 package tech.pegasys.teku.statetransition.datacolumns;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.Optional;
@@ -24,7 +26,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Stream;
+
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
@@ -87,9 +89,10 @@ public class DataColumnSidecarDBStub implements DataColumnSidecarDB {
   }
 
   @Override
-  public SafeFuture<Stream<DataColumnIdentifier>> streamColumnIdentifiers(UInt64 slot) {
+  public SafeFuture<List<DataColumnIdentifier>> getColumnIdentifiers(UInt64 slot) {
     dbReadCounter.incrementAndGet();
-    return SafeFuture.completedFuture(slotIds.getOrDefault(slot, Collections.emptySet()).stream());
+    return SafeFuture.completedFuture(
+        new ArrayList<>(slotIds.getOrDefault(slot, Collections.emptySet())));
   }
 
   @Override

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -149,7 +149,7 @@ import tech.pegasys.teku.statetransition.datacolumns.DasSamplerBasic;
 import tech.pegasys.teku.statetransition.datacolumns.DasSamplerManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarCustodyImpl;
-import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarDBImpl;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDBImpl;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarManager;
 import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarManagerImpl;
 import tech.pegasys.teku.statetransition.datacolumns.LateInitDataColumnSidecarCustody;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

The step to #117 

- Move `DataColumnSidecarDB` to `db` sub-package
- `DataColumnSidecarDB`: rename `streamColumnIdentifiers()` to `getColumnIdentifiers()` and change `Stream` to `List`
- Add `DataColumnSidecarDbAccessor` concept as a higher level DB accessor 
- Add `DataColumnSidecarDbAccessorBuilder` concept as a higher level DB accessor 
- Replace `DataColumnSidecarDB` with `DataColumnSidecarDbAccessor`. 
- Add db auto pruning class `AutoPruningDasDb`
- Add a test for `AutoPruningDasDb`
