### PR TITLE
Improve confusing logging

### DIFF
--- a/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LogFormatter.java
+++ b/infrastructure/logging/src/main/java/tech/pegasys/teku/infrastructure/logging/LogFormatter.java
@@ -38,7 +38,7 @@ public class LogFormatter {
       final String kzgCommitment,
       final String kzgProof) {
     return String.format(
-        "block %s (%s), index %s, blob %s, commitment %s, proof %s",
+        "BlobSidecar[block %s (%s), index %s, blob %s, commitment %s, proof %s]",
         formatAbbreviatedHashRoot(blockRoot), slot, index, blob, kzgCommitment, kzgProof);
   }
 
@@ -50,7 +50,7 @@ public class LogFormatter {
       final int kzgCommitmentsSize,
       final int kzgProofsSize) {
     return String.format(
-        "block %s (%s), index %s, 1st cell %s, commitments %s, proofs %s",
+        "DataColumnSidecar[block %s (%s), index %s, 1st cell %s, commitments %s, proofs %s]",
         formatAbbreviatedHashRoot(blockRoot), slot, index, blob, kzgCommitmentsSize, kzgProofsSize);
   }
 }


### PR DESCRIPTION
```

2024-09-08 14:00:34.214 INFO  - Collected block ce60ff..902c (327), index 23, 1st cell 00000000000000, commitments 6, proofs 6,block ce60ff..902c (327), index 55, 1st cell 00000000000000, commitments 6, proofs 6,block ce60ff..902c (327), index 80, 1st cell 0c3323a01173ea, commitments 6, proofs 6,block ce60ff..902c (327), index 98, 1st cell 56f17efac9a099, commitments 6, proofs 6 DataColumnSidecars in checkDataAvailability for 0xce60fff4ac3c0c4c626db51afd4eeef796bc2884556050b692b2c93d180e902c(327)
```
It looked like block was collected, fixing