### PR TITLE
Return SafeFuture<Void> from DataColumnSidecarDB update methods

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
@@ -61,13 +61,17 @@ public class DasCustodySync implements SlotEventsChannel {
   }
 
   private void onRequestComplete(PendingRequest request, DataColumnSidecar response) {
-    custody.onNewValidatedDataColumnSidecar(response).thenRun(() -> {
-      synchronized (this) {
-        pendingRequests.remove(request.columnId);
-        syncedColumnCount.incrementAndGet();
-        fillUpIfNeeded();
-      }
-    }).ifExceptionGetsHereRaiseABug();
+    custody
+        .onNewValidatedDataColumnSidecar(response)
+        .thenRun(
+            () -> {
+              synchronized (this) {
+                pendingRequests.remove(request.columnId);
+                syncedColumnCount.incrementAndGet();
+                fillUpIfNeeded();
+              }
+            })
+        .ifExceptionGetsHereRaiseABug();
   }
 
   private boolean wasCancelledImplicitly(Throwable exception) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
@@ -61,12 +61,13 @@ public class DasCustodySync implements SlotEventsChannel {
   }
 
   private void onRequestComplete(PendingRequest request, DataColumnSidecar response) {
-    custody.onNewValidatedDataColumnSidecar(response);
-    synchronized (this) {
-      pendingRequests.remove(request.columnId);
-      syncedColumnCount.incrementAndGet();
-      fillUpIfNeeded();
-    }
+    custody.onNewValidatedDataColumnSidecar(response).thenRun(() -> {
+      synchronized (this) {
+        pendingRequests.remove(request.columnId);
+        syncedColumnCount.incrementAndGet();
+        fillUpIfNeeded();
+      }
+    }).ifExceptionGetsHereRaiseABug();
   }
 
   private boolean wasCancelledImplicitly(Throwable exception) {

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -127,7 +127,7 @@ public class DataColumnSidecarCustodyImpl
   }
 
   @Override
-  public SafeFuture<Void>  onNewValidatedDataColumnSidecar(DataColumnSidecar dataColumnSidecar) {
+  public SafeFuture<Void> onNewValidatedDataColumnSidecar(DataColumnSidecar dataColumnSidecar) {
     if (isMyCustody(dataColumnSidecar.getSlot(), dataColumnSidecar.getIndex())) {
       final DataColumnIdentifier dataColumnIdentifier =
           DataColumnIdentifier.createFromSidecar(dataColumnSidecar);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -127,14 +127,16 @@ public class DataColumnSidecarCustodyImpl
   }
 
   @Override
-  public void onNewValidatedDataColumnSidecar(DataColumnSidecar dataColumnSidecar) {
+  public SafeFuture<Void>  onNewValidatedDataColumnSidecar(DataColumnSidecar dataColumnSidecar) {
     if (isMyCustody(dataColumnSidecar.getSlot(), dataColumnSidecar.getIndex())) {
       final DataColumnIdentifier dataColumnIdentifier =
           DataColumnIdentifier.createFromSidecar(dataColumnSidecar);
       knownSavedIdentifiers.put(
           dataColumnIdentifier,
           new ColumnSlotAndIdentifier(dataColumnSidecar.getSlot(), dataColumnIdentifier));
-      db.addSidecar(dataColumnSidecar).ifExceptionGetsHereRaiseABug();
+      return db.addSidecar(dataColumnSidecar).ifExceptionGetsHereRaiseABug();
+    } else {
+      return SafeFuture.COMPLETE;
     }
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -134,7 +134,7 @@ public class DataColumnSidecarCustodyImpl
       knownSavedIdentifiers.put(
           dataColumnIdentifier,
           new ColumnSlotAndIdentifier(dataColumnSidecar.getSlot(), dataColumnIdentifier));
-      return db.addSidecar(dataColumnSidecar).ifExceptionGetsHereRaiseABug();
+      return db.addSidecar(dataColumnSidecar);
     } else {
       return SafeFuture.COMPLETE;
     }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImpl.java
@@ -134,7 +134,7 @@ public class DataColumnSidecarCustodyImpl
       knownSavedIdentifiers.put(
           dataColumnIdentifier,
           new ColumnSlotAndIdentifier(dataColumnSidecar.getSlot(), dataColumnIdentifier));
-      db.addSidecar(dataColumnSidecar);
+      db.addSidecar(dataColumnSidecar).ifExceptionGetsHereRaiseABug();
     }
   }
 

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/UpdatableDataColumnSidecarCustody.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/UpdatableDataColumnSidecarCustody.java
@@ -13,12 +13,13 @@
 
 package tech.pegasys.teku.statetransition.datacolumns;
 
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 
 public interface UpdatableDataColumnSidecarCustody extends DataColumnSidecarCustody {
 
-  void onNewValidatedDataColumnSidecar(DataColumnSidecar dataColumnSidecar);
+  SafeFuture<Void> onNewValidatedDataColumnSidecar(DataColumnSidecar dataColumnSidecar);
 
   AsyncStream<DataColumnSlotAndIdentifier> retrieveMissingColumns();
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/AbstractDelegatingDasDb.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/AbstractDelegatingDasDb.java
@@ -44,7 +44,7 @@ abstract class AbstractDelegatingDasDb implements DataColumnSidecarCoreDB {
   }
 
   @Override
-  public void addSidecar(DataColumnSidecar sidecar) {
-    delegateDb.addSidecar(sidecar);
+  public SafeFuture<Void> addSidecar(DataColumnSidecar sidecar) {
+    return delegateDb.addSidecar(sidecar);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarCoreDB.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarCoreDB.java
@@ -32,5 +32,5 @@ interface DataColumnSidecarCoreDB {
   SafeFuture<List<DataColumnIdentifier>> getColumnIdentifiers(UInt64 slot);
 
   // update
-  void addSidecar(DataColumnSidecar sidecar);
+  SafeFuture<Void> addSidecar(DataColumnSidecar sidecar);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDB.java
@@ -53,7 +53,7 @@ public interface DataColumnSidecarDB extends DataColumnSidecarCoreDB {
   SafeFuture<Void> setFirstSamplerIncompleteSlot(UInt64 slot);
 
   @Override
-  void addSidecar(DataColumnSidecar sidecar);
+  SafeFuture<Void> addSidecar(DataColumnSidecar sidecar);
 
-  void pruneAllSidecars(UInt64 tillSlot);
+  SafeFuture<Void> pruneAllSidecars(UInt64 tillSlot);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
@@ -110,7 +110,7 @@ class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
   @Override
   public SafeFuture<Void> setFirstSamplerIncompleteSlot(final UInt64 slot) {
     return getFirstSamplerIncompleteSlot()
-        .thenCompose(maybeCurrentSlot -> logNewFirstSamplerIncompleteSlot(maybeCurrentSlot, slot))
+        .thenAccept(maybeCurrentSlot -> logNewFirstSamplerIncompleteSlot(maybeCurrentSlot, slot))
         .thenCompose(__ -> sidecarUpdateChannel.onFirstSamplerIncompleteSlot(slot));
   }
 
@@ -155,7 +155,7 @@ class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
     return sidecarUpdateChannel.onSidecarsAvailabilitySlot(tillSlotExclusive);
   }
 
-  private SafeFuture<Void> logNewFirstSamplerIncompleteSlot(
+  private void logNewFirstSamplerIncompleteSlot(
       Optional<UInt64> maybeCurrentSlot, final UInt64 newSlot) {
     if (maybeCurrentSlot.isEmpty() || !maybeCurrentSlot.get().equals(newSlot)) {
       LOG.info(
@@ -163,6 +163,5 @@ class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
           maybeCurrentSlot.map(UInt64::toString).orElse("NA"),
           newSlot);
     }
-    return SafeFuture.COMPLETE;
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarDBImpl.java
@@ -74,56 +74,23 @@ class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
   @Override
   public SafeFuture<Void> setFirstCustodyIncompleteSlot(final UInt64 slot) {
     return getFirstCustodyIncompleteSlot()
-        .thenAccept(
-            maybeFirstIncompleteSlot -> {
-              sidecarUpdateChannel.onFirstCustodyIncompleteSlot(slot);
-              if (maybeFirstIncompleteSlot.isEmpty()
-                  || !maybeFirstIncompleteSlot.get().equals(slot)) {
-                getColumnIdentifiers(slot)
-                    .thenCompose(
-                        newSlotColumnIdentifiers -> {
-                          final long newSlotCount = newSlotColumnIdentifiers.size();
-                          if (maybeFirstIncompleteSlot.isEmpty()) {
-                            return SafeFuture.completedFuture(Pair.of(0L, newSlotCount));
-                          } else {
-                            return getColumnIdentifiers(maybeFirstIncompleteSlot.get())
-                                .thenApply(
-                                    dataColumnIdentifierStream ->
-                                        Pair.of(dataColumnIdentifierStream.size(), newSlotCount));
-                          }
-                        })
-                    .thenPeek(
-                        oldCountNewCount ->
-                            LOG.info(
-                                "[nyota] DataColumnSidecarDB: setFirstCustodyIncompleteSlot {} ({} cols) ~> {} ({} cols)",
-                                maybeFirstIncompleteSlot.map(UInt64::toString).orElse("NA"),
-                                oldCountNewCount.left(),
-                                slot,
-                                oldCountNewCount.right()))
-                    .ifExceptionGetsHereRaiseABug();
-              }
-            });
+        .thenCompose(maybeCurrentSlot -> logNewFirstCustodyIncompleteSlot(maybeCurrentSlot, slot))
+        .thenCompose(__ -> sidecarUpdateChannel.onFirstCustodyIncompleteSlot(slot));
   }
 
   @Override
   public SafeFuture<Void> setFirstSamplerIncompleteSlot(final UInt64 slot) {
     return getFirstSamplerIncompleteSlot()
-        .thenAccept(
-            maybeFirstIncompleteSlot -> {
-              sidecarUpdateChannel.onFirstSamplerIncompleteSlot(slot);
-              if (maybeFirstIncompleteSlot.isEmpty()
-                  || !maybeFirstIncompleteSlot.get().equals(slot)) {
-                LOG.info(
-                    "[nyota] DataColumnSidecarDB: setFirstSamplerIncompleteSlot {} ~> {}",
-                    maybeFirstIncompleteSlot.map(UInt64::toString).orElse("NA"),
-                    slot);
-              }
-            });
+        .thenCompose(maybeCurrentSlot -> logNewFirstSamplerIncompleteSlot(maybeCurrentSlot, slot))
+        .thenCompose(__ -> sidecarUpdateChannel.onFirstSamplerIncompleteSlot(slot));
   }
 
   @Override
-  public void addSidecar(final DataColumnSidecar sidecar) {
-    sidecarUpdateChannel.onNewSidecar(sidecar);
+  public SafeFuture<Void> addSidecar(final DataColumnSidecar sidecar) {
+    return sidecarUpdateChannel.onNewSidecar(sidecar).thenRun(() -> logOnNewSidecar(sidecar));
+  }
+
+  private synchronized void logOnNewSidecar(DataColumnSidecar sidecar) {
     addCounter.incrementAndGet();
     int slot = sidecar.getSlot().intValue();
     synchronized (this) {
@@ -155,7 +122,47 @@ class DataColumnSidecarDBImpl implements DataColumnSidecarDB {
   }
 
   @Override
-  public void pruneAllSidecars(final UInt64 tillSlotExclusive) {
-    sidecarUpdateChannel.onSidecarsAvailabilitySlot(tillSlotExclusive);
+  public SafeFuture<Void> pruneAllSidecars(final UInt64 tillSlotExclusive) {
+    return sidecarUpdateChannel.onSidecarsAvailabilitySlot(tillSlotExclusive);
+  }
+
+  private SafeFuture<Void> logNewFirstCustodyIncompleteSlot(
+      Optional<UInt64> maybeCurrentSlot, final UInt64 newSlot) {
+    if (maybeCurrentSlot.isEmpty() || !maybeCurrentSlot.get().equals(newSlot)) {
+      return getColumnIdentifiers(newSlot)
+          .thenCompose(
+              newSlotColumnIdentifiers -> {
+                final long newSlotCount = newSlotColumnIdentifiers.size();
+                if (maybeCurrentSlot.isEmpty()) {
+                  return SafeFuture.completedFuture(Pair.of(0L, newSlotCount));
+                } else {
+                  return getColumnIdentifiers(maybeCurrentSlot.get())
+                      .thenApply(
+                          dataColumnIdentifierStream ->
+                              Pair.of(dataColumnIdentifierStream.size(), newSlotCount));
+                }
+              })
+          .thenAccept(
+              oldCountNewCount ->
+                  LOG.info(
+                      "[nyota] DataColumnSidecarDB: setFirstCustodyIncompleteSlot {} ({} cols) ~> {} ({} cols)",
+                      maybeCurrentSlot.map(UInt64::toString).orElse("NA"),
+                      oldCountNewCount.left(),
+                      newSlot,
+                      oldCountNewCount.right()));
+    } else {
+      return SafeFuture.COMPLETE;
+    }
+  }
+
+  private SafeFuture<Void> logNewFirstSamplerIncompleteSlot(
+      Optional<UInt64> maybeCurrentSlot, final UInt64 newSlot) {
+    if (maybeCurrentSlot.isEmpty() || !maybeCurrentSlot.get().equals(newSlot)) {
+      LOG.info(
+          "[nyota] DataColumnSidecarDB: setFirstSamplerIncompleteSlot {} ~> {}",
+          maybeCurrentSlot.map(UInt64::toString).orElse("NA"),
+          newSlot);
+    }
+    return SafeFuture.COMPLETE;
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
@@ -36,7 +36,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
-@SuppressWarnings("JavaCase")
+@SuppressWarnings({"JavaCase", "FutureReturnValueIgnored"})
 public class DasLongPollCustodyTest {
   final StubTimeProvider stubTimeProvider = StubTimeProvider.withTimeInSeconds(0);
   final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner(stubTimeProvider);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarCustodyImplTest.java
@@ -33,6 +33,7 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
+@SuppressWarnings({"JavaCase", "FutureReturnValueIgnored"})
 public class DataColumnSidecarCustodyImplTest {
 
   final Spec spec = TestSpecFactory.createMinimalEip7594();
@@ -58,7 +59,6 @@ public class DataColumnSidecarCustodyImplTest {
   }
 
   @Test
-  @SuppressWarnings("JavaCase")
   void sanityTest() throws Throwable {
     DataColumnSidecarCustodyImpl custody =
         new DataColumnSidecarCustodyImpl(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/db/AutoPruningDasDbTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/db/AutoPruningDasDbTest.java
@@ -26,6 +26,7 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIde
 import tech.pegasys.teku.statetransition.datacolumns.DasCustodyStand;
 import tech.pegasys.teku.statetransition.datacolumns.MinCustodyPeriodSlotCalculator;
 
+@SuppressWarnings("FutureReturnValueIgnored")
 public class AutoPruningDasDbTest {
   final Spec spec = TestSpecFactory.createMinimalEip7594();
   final DasCustodyStand das = DasCustodyStand.builder(spec).build();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -44,6 +44,7 @@ import tech.pegasys.teku.statetransition.datacolumns.DataColumnSlotAndIdentifier
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
+@SuppressWarnings("FutureReturnValueIgnored")
 public class RecoveringSidecarRetrieverTest {
 
   final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner();

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DataColumnSidecarDBStub.java
@@ -69,11 +69,12 @@ public class DataColumnSidecarDBStub implements DataColumnSidecarDB {
   }
 
   @Override
-  public void addSidecar(DataColumnSidecar sidecar) {
+  public SafeFuture<Void> addSidecar(DataColumnSidecar sidecar) {
     dbWriteCounter.incrementAndGet();
     DataColumnIdentifier identifier = DataColumnIdentifier.createFromSidecar(sidecar);
     db.put(identifier, sidecar);
     slotIds.computeIfAbsent(sidecar.getSlot(), __ -> new HashSet<>()).add(identifier);
+    return SafeFuture.COMPLETE;
   }
 
   @Override
@@ -95,11 +96,12 @@ public class DataColumnSidecarDBStub implements DataColumnSidecarDB {
   }
 
   @Override
-  public void pruneAllSidecars(UInt64 tillSlot) {
+  public SafeFuture<Void> pruneAllSidecars(UInt64 tillSlot) {
     dbWriteCounter.incrementAndGet();
     SortedMap<UInt64, Set<DataColumnIdentifier>> slotsToPrune = slotIds.headMap(tillSlot);
     slotsToPrune.values().stream().flatMap(Collection::stream).forEach(db::remove);
     slotsToPrune.clear();
+    return SafeFuture.COMPLETE;
   }
 
   public AtomicLong getDbReadCounter() {

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -466,7 +466,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
                     storageQueryChannel,
                     storageUpdateChannel,
                     voteUpdateChannel,
-                    eventChannels.getPublisher(SidecarUpdateChannel.class),
+                    eventChannels.getPublisher(SidecarUpdateChannel.class, beaconAsyncRunner),
                     eventChannels.getPublisher(FinalizedCheckpointChannel.class, beaconAsyncRunner),
                     coalescingChainHeadChannel,
                     validatorIsConnectedProvider,
@@ -670,7 +670,7 @@ public class BeaconChainController extends Service implements BeaconChainControl
       int slotsPerEpoch = configEip7594.getSlotsPerEpoch();
       DataColumnSidecarDB sidecarDB =
           DataColumnSidecarDB.create(
-              combinedChainDataClient, eventChannels.getPublisher(SidecarUpdateChannel.class));
+              combinedChainDataClient, eventChannels.getPublisher(SidecarUpdateChannel.class, beaconAsyncRunner));
       dbAccessor =
           DataColumnSidecarDbAccessor.builder(sidecarDB)
               .spec(spec)

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -670,7 +670,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
       int slotsPerEpoch = configEip7594.getSlotsPerEpoch();
       DataColumnSidecarDB sidecarDB =
           DataColumnSidecarDB.create(
-              combinedChainDataClient, eventChannels.getPublisher(SidecarUpdateChannel.class, beaconAsyncRunner));
+              combinedChainDataClient,
+              eventChannels.getPublisher(SidecarUpdateChannel.class, beaconAsyncRunner));
       dbAccessor =
           DataColumnSidecarDbAccessor.builder(sidecarDB)
               .spec(spec)
@@ -708,7 +709,10 @@ public class BeaconChainController extends Service implements BeaconChainControl
         new DasLongPollCustody(
             dataColumnSidecarCustodyImpl, operationPoolAsyncRunner, spec, Duration.ofSeconds(5));
     dataColumnSidecarManager.subscribeToValidDataColumnSidecars(
-        custody::onNewValidatedDataColumnSidecar);
+        dataColumnSidecar ->
+            custody
+                .onNewValidatedDataColumnSidecar(dataColumnSidecar)
+                .ifExceptionGetsHereRaiseABug());
     // TODO fix this dirty hack
     // This is to resolve the initialization loop Network <--> DAS Custody
     this.dataColumnSidecarCustody.init(custody);

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/SidecarUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/SidecarUpdateChannel.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.storage.api;
 
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.events.ChannelInterface;
-import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 

--- a/storage/api/src/main/java/tech/pegasys/teku/storage/api/SidecarUpdateChannel.java
+++ b/storage/api/src/main/java/tech/pegasys/teku/storage/api/SidecarUpdateChannel.java
@@ -13,20 +13,22 @@
 
 package tech.pegasys.teku.storage.api;
 
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.events.ChannelInterface;
 import tech.pegasys.teku.infrastructure.events.VoidReturningChannelInterface;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 
-public interface SidecarUpdateChannel extends VoidReturningChannelInterface {
+public interface SidecarUpdateChannel extends ChannelInterface {
 
   // TODO: as it's pushed separately from sidecars, an eventual consistency could occur.
   //  Clarify that it's safe
-  void onFirstCustodyIncompleteSlot(UInt64 slot);
+  SafeFuture<Void> onFirstCustodyIncompleteSlot(UInt64 slot);
 
-  void onFirstSamplerIncompleteSlot(UInt64 slot);
+  SafeFuture<Void> onFirstSamplerIncompleteSlot(UInt64 slot);
 
-  void onNewSidecar(DataColumnSidecar sidecar);
+  SafeFuture<Void> onNewSidecar(DataColumnSidecar sidecar);
 
   // TODO: Make a dedicated pruner instead
-  void onSidecarsAvailabilitySlot(UInt64 earliestSlotRequired);
+  SafeFuture<Void> onSidecarsAvailabilitySlot(UInt64 earliestSlotRequired);
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/ChainStorage.java
@@ -412,22 +412,23 @@ public class ChainStorage
   }
 
   @Override
-  public void onFirstCustodyIncompleteSlot(final UInt64 slot) {
-    database.setFirstCustodyIncompleteSlot(slot);
+  public SafeFuture<Void> onFirstCustodyIncompleteSlot(final UInt64 slot) {
+    return SafeFuture.fromRunnable(() -> database.setFirstCustodyIncompleteSlot(slot));
   }
 
   @Override
-  public void onFirstSamplerIncompleteSlot(final UInt64 slot) {
-    database.setFirstSamplerIncompleteSlot(slot);
+  public SafeFuture<Void> onFirstSamplerIncompleteSlot(final UInt64 slot) {
+    return SafeFuture.fromRunnable(() -> database.setFirstSamplerIncompleteSlot(slot));
   }
 
   @Override
-  public void onNewSidecar(final DataColumnSidecar sidecar) {
-    database.addSidecar(sidecar);
+  public SafeFuture<Void> onNewSidecar(final DataColumnSidecar sidecar) {
+    return SafeFuture.fromRunnable(() -> database.addSidecar(sidecar));
   }
 
   @Override
-  public void onSidecarsAvailabilitySlot(final UInt64 earliestSlotRequired) {
-    database.pruneAllSidecars(earliestSlotRequired.minusMinZero(1));
+  public SafeFuture<Void> onSidecarsAvailabilitySlot(final UInt64 earliestSlotRequired) {
+    return SafeFuture.fromRunnable(
+        () -> database.pruneAllSidecars(earliestSlotRequired.minusMinZero(1)));
   }
 }

--- a/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubSidecarUpdateChannel.java
+++ b/storage/src/testFixtures/java/tech/pegasys/teku/storage/api/StubSidecarUpdateChannel.java
@@ -13,19 +13,28 @@
 
 package tech.pegasys.teku.storage.api;
 
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 
 public class StubSidecarUpdateChannel implements SidecarUpdateChannel {
   @Override
-  public void onFirstCustodyIncompleteSlot(UInt64 slot) {}
+  public SafeFuture<Void> onFirstCustodyIncompleteSlot(UInt64 slot) {
+    return SafeFuture.COMPLETE;
+  }
 
   @Override
-  public void onFirstSamplerIncompleteSlot(UInt64 slot) {}
+  public SafeFuture<Void> onFirstSamplerIncompleteSlot(UInt64 slot) {
+    return SafeFuture.COMPLETE;
+  }
 
   @Override
-  public void onNewSidecar(DataColumnSidecar sidecar) {}
+  public SafeFuture<Void> onNewSidecar(DataColumnSidecar sidecar) {
+    return SafeFuture.COMPLETE;
+  }
 
   @Override
-  public void onSidecarsAvailabilitySlot(UInt64 earliestSlotRequired) {}
+  public SafeFuture<Void> onSidecarsAvailabilitySlot(UInt64 earliestSlotRequired) {
+    return SafeFuture.COMPLETE;
+  }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Return `SafeFuture<Void>` from `DataColumnSidecarDB` update methods to have the possiblity to be notified when changes are committed to DB 
- As well return `SafeFuture<Void>` from `DataColumnSidecarCustody.onNewValidatedDataColumnSidecar()`. Without this commit motification it is not possible to implement `DasLongPollCustody` in a reliable fashion
