### PR TITLE
Performance tweaks with benchmarks + blobSidecarPool traces removed

### DIFF
--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherEip7594.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/BlockPublisherEip7594.java
@@ -23,7 +23,6 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobSidecar;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.validator.BroadcastValidationLevel;
-import tech.pegasys.teku.statetransition.blobs.BlockBlobSidecarsTrackersPool;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel;
 import tech.pegasys.teku.statetransition.block.BlockImportChannel.BlockImportAndBroadcastValidationResults;
 import tech.pegasys.teku.validator.coordinator.BlockFactory;
@@ -32,7 +31,6 @@ import tech.pegasys.teku.validator.coordinator.performance.PerformanceTracker;
 
 public class BlockPublisherEip7594 extends AbstractBlockPublisher {
 
-  private final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool;
   private final BlockGossipChannel blockGossipChannel;
   private final DataColumnSidecarGossipChannel dataColumnSidecarGossipChannel;
 
@@ -40,12 +38,10 @@ public class BlockPublisherEip7594 extends AbstractBlockPublisher {
       final BlockFactory blockFactory,
       final BlockImportChannel blockImportChannel,
       final BlockGossipChannel blockGossipChannel,
-      final BlockBlobSidecarsTrackersPool blockBlobSidecarsTrackersPool,
       final DataColumnSidecarGossipChannel dataColumnSidecarGossipChannel,
       final PerformanceTracker performanceTracker,
       final DutyMetrics dutyMetrics) {
     super(blockFactory, blockImportChannel, performanceTracker, dutyMetrics);
-    this.blockBlobSidecarsTrackersPool = blockBlobSidecarsTrackersPool;
     this.blockGossipChannel = blockGossipChannel;
     this.dataColumnSidecarGossipChannel = dataColumnSidecarGossipChannel;
   }
@@ -57,8 +53,6 @@ public class BlockPublisherEip7594 extends AbstractBlockPublisher {
       final BroadcastValidationLevel broadcastValidationLevel,
       final BlockPublishingPerformance blockPublishingPerformance) {
     // TODO: DataColumnSidecars pool fill up
-    // provide blobs for the block before importing it
-    blockBlobSidecarsTrackersPool.onCompletedBlockAndBlobSidecars(block, blobSidecars);
     return blockImportChannel
         .importBlock(block, broadcastValidationLevel)
         .thenPeek(__ -> blockPublishingPerformance.blockImportCompleted());

--- a/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
+++ b/beacon/validator/src/main/java/tech/pegasys/teku/validator/coordinator/publisher/MilestoneBasedBlockPublisher.java
@@ -72,7 +72,6 @@ public class MilestoneBasedBlockPublisher implements BlockPublisher {
                     blockFactory,
                     blockImportChannel,
                     blockGossipChannel,
-                    blockBlobSidecarsTrackersPool,
                     dataColumnSidecarGossipChannel,
                     performanceTracker,
                     dutyMetrics));

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/datastructures/blobs/versions/deneb/BlobTest.java
@@ -32,7 +32,7 @@ class BlobTest {
   private final BlobSchema blobSchema =
       schemaDefinitions.toVersionDeneb().orElseThrow().getBlobSchema();
 
-  private final Bytes correctData = dataStructureUtil.randomBlob().getBytes();
+  private final Bytes correctData = dataStructureUtil.randomValidBlob().getBytes();
 
   @Test
   public void objectEquality() {

--- a/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDenebTest.java
+++ b/ethereum/spec/src/test/java/tech/pegasys/teku/spec/logic/versions/deneb/helpers/MiscHelpersDenebTest.java
@@ -191,7 +191,7 @@ class MiscHelpersDenebTest {
   void shouldConstructValidBlobSidecar() {
     final SignedBeaconBlock signedBeaconBlock =
         dataStructureUtil.randomSignedBeaconBlockWithCommitments(1);
-    final Blob blob = dataStructureUtil.randomBlob();
+    final Blob blob = dataStructureUtil.randomValidBlob();
     final SszKZGCommitment expectedCommitment =
         BeaconBlockBodyDeneb.required(signedBeaconBlock.getMessage().getBody())
             .getBlobKzgCommitments()
@@ -214,7 +214,7 @@ class MiscHelpersDenebTest {
   void shouldThrowWhenConstructingBlobSidecarWithInvalidIndex() {
     final SignedBeaconBlock signedBeaconBlock =
         dataStructureUtil.randomSignedBeaconBlockWithCommitments(1);
-    final Blob blob = dataStructureUtil.randomBlob();
+    final Blob blob = dataStructureUtil.randomValidBlob();
     final SszKZGProof proof = dataStructureUtil.randomSszKZGProof();
 
     assertThatThrownBy(

--- a/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/blobs/versions/deneb/BlobSupplier.java
+++ b/ethereum/spec/src/testFixtures/java/tech/pegasys/teku/spec/propertytest/suppliers/blobs/versions/deneb/BlobSupplier.java
@@ -20,6 +20,6 @@ import tech.pegasys.teku.spec.util.DataStructureUtil;
 
 public class BlobSupplier extends DataStructureUtilSupplier<Blob> {
   public BlobSupplier() {
-    super(DataStructureUtil::randomBlob, SpecMilestone.DENEB);
+    super(DataStructureUtil::randomValidBlob, SpecMilestone.DENEB);
   }
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityChecker.java
@@ -110,6 +110,7 @@ public class DataColumnSidecarAvailabilityChecker
     }
     final boolean isNotValid =
         dataColumnSidecars.stream()
+            .parallel()
             .map(
                 dataColumnSidecar ->
                     spec.atSlot(dataColumnSidecar.getSlot())

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -95,7 +95,8 @@ public class RecoveringSidecarRetrieverTest {
             stubAsyncRunner,
             Duration.ofSeconds(1),
             128);
-    List<Blob> blobs = Stream.generate(dataStructureUtil::randomBlob).limit(blobCount).toList();
+    List<Blob> blobs =
+        Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
     BeaconBlock block = blockResolver.addBlock(10, blobCount);
     List<DataColumnSidecar> sidecars =
         miscHelpers.constructDataColumnSidecars(createSigned(block), blobs, kzg);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SampleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SampleSidecarRetrieverTest.java
@@ -127,7 +127,7 @@ public class SampleSidecarRetrieverTest {
     TestPeer nonCustodyPeer =
         new TestPeer(stubAsyncRunner, nonCustodyNodeIds.next(), Duration.ofMillis(100));
 
-    List<Blob> blobs = Stream.generate(dataStructureUtil::randomBlob).limit(1).toList();
+    List<Blob> blobs = Stream.generate(dataStructureUtil::randomValidBlob).limit(1).toList();
     BeaconBlock block = blockResolver.addBlock(10, 1);
     List<DataColumnSidecar> sidecars =
         miscHelpers.constructDataColumnSidecars(createSigned(block), blobs, kzg);

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerBenchmarkTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/forkchoice/DataColumnSidecarAvailabilityCheckerBenchmarkTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.statetransition.forkchoice;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.kzg.KZGAbstractBenchmark;
+import tech.pegasys.teku.spec.Spec;
+import tech.pegasys.teku.spec.SpecMilestone;
+import tech.pegasys.teku.spec.TestSpecFactory;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.Blob;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.deneb.BlobKzgCommitmentsSchema;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
+import tech.pegasys.teku.spec.datastructures.forkchoice.ReadOnlyStore;
+import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
+import tech.pegasys.teku.spec.logic.common.statetransition.availability.DataAndValidationResult;
+import tech.pegasys.teku.spec.schemas.SchemaDefinitionsDeneb;
+import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.datacolumns.DataAvailabilitySampler;
+
+@Disabled("Benchmark")
+public class DataColumnSidecarAvailabilityCheckerBenchmarkTest extends KZGAbstractBenchmark {
+  private final DataAvailabilitySampler dataAvailabilitySampler =
+      mock(DataAvailabilitySampler.class);
+  private final ReadOnlyStore store = mock(ReadOnlyStore.class);
+  private static final int ROUNDS = 10;
+
+  private final Spec spec = TestSpecFactory.createMinimalEip7594();
+  private final DataStructureUtil dataStructureUtil = new DataStructureUtil(spec);
+
+  @Test
+  public void benchmarkValidateImmediately() {
+    final List<Blob> blobs =
+        IntStream.range(0, 6).mapToObj(__ -> dataStructureUtil.randomValidBlob()).toList();
+    final List<SszKZGCommitment> kzgCommitments =
+        blobs.stream()
+            .map(blob -> getKzg().blobToKzgCommitment(blob.getBytes()))
+            .map(SszKZGCommitment::new)
+            .toList();
+    final BlobKzgCommitmentsSchema blobKzgCommitmentsSchema =
+        SchemaDefinitionsDeneb.required(spec.atSlot(UInt64.ONE).getSchemaDefinitions())
+            .getBlobKzgCommitmentsSchema();
+    final SignedBeaconBlock signedBeaconBlock =
+        dataStructureUtil.randomSignedBeaconBlockWithCommitments(
+            blobKzgCommitmentsSchema.createFromElements(kzgCommitments));
+    final List<DataColumnSidecar> dataColumnSidecars =
+        spec.forMilestone(SpecMilestone.EIP7594)
+            .miscHelpers()
+            .toVersionEip7594()
+            .orElseThrow()
+            .constructDataColumnSidecars(signedBeaconBlock, blobs, getKzg());
+
+    final List<Integer> validationTimes = new ArrayList<>();
+    for (int i = 0; i < ROUNDS; i++) {
+      final long start = System.currentTimeMillis();
+      final DataColumnSidecarAvailabilityChecker dataColumnSidecarAvailabilityChecker =
+          new DataColumnSidecarAvailabilityChecker(
+              dataAvailabilitySampler, store, getKzg(), spec, signedBeaconBlock);
+      final DataAndValidationResult<DataColumnSidecar> dataColumnSidecarDataAndValidationResult =
+          dataColumnSidecarAvailabilityChecker.validateImmediately(dataColumnSidecars);
+      assertThat(dataColumnSidecarDataAndValidationResult.isValid()).isTrue();
+      final long end = System.currentTimeMillis();
+      validationTimes.add((int) (end - start));
+    }
+
+    printStats(validationTimes);
+  }
+}

--- a/infrastructure/kzg/src/testFixtures/java/tech/pegasys/teku/kzg/KZGAbstractBenchmark.java
+++ b/infrastructure/kzg/src/testFixtures/java/tech/pegasys/teku/kzg/KZGAbstractBenchmark.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.kzg;
+
+import java.util.Collections;
+import java.util.List;
+import tech.pegasys.teku.kzg.trusted_setups.TrustedSetupLoader;
+
+public class KZGAbstractBenchmark {
+  private final KZG kzg = KZG.getInstance(false);
+
+  public KZGAbstractBenchmark() {
+    TrustedSetupLoader.loadTrustedSetupForTests(kzg);
+  }
+
+  protected KZG getKzg() {
+    return kzg;
+  }
+
+  protected void printStats(List<Integer> validationTimes) {
+    int sum = 0;
+    int size = validationTimes.size();
+
+    // Sum of elements
+    for (int time : validationTimes) {
+      sum += time;
+    }
+
+    // Mean
+    double mean = (double) sum / size;
+    System.out.printf("Mean, ms: %.2f%n", mean);
+
+    // Standard Deviation
+    double sumOfSquares = 0.0;
+    for (int time : validationTimes) {
+      sumOfSquares += Math.pow(time - mean, 2);
+    }
+    double standardDeviation = Math.sqrt(sumOfSquares / size);
+    System.out.printf("Std, ms: %.2f%n", standardDeviation);
+
+    // Min and Max
+    int min = Collections.min(validationTimes);
+    int max = Collections.max(validationTimes);
+    System.out.println("Min, ms: " + min);
+    System.out.println("Max, ms: " + max);
+  }
+}


### PR DESCRIPTION
Checked 3 places to tweak with parallel execution:
- availabilityChecker kzg verification, good gain, altered with parallel stream
- miscHelper: construct extended matrix, good gain, altered with parallel stream
- miscHelper: construct DataColumnSidecars from existing matrix, almost no gains, kzg not involved, not altered. 


bonus: found one place where I forgot to remove blobSidecar pool traces in EIP-7594