### PR TITLE
Fix AsyncStream issue which stuck DAS sync

### DIFF
--- a/ethereum/statetransition/build.gradle
+++ b/ethereum/statetransition/build.gradle
@@ -50,6 +50,7 @@ dependencies {
   testFixturesImplementation project(':infrastructure:time')
   testFixturesImplementation testFixtures(project(':ethereum:spec'))
   testFixturesImplementation testFixtures(project(':infrastructure:metrics'))
+  testFixturesImplementation testFixtures(project(':infrastructure:time'))
   testImplementation testFixtures(project(':infrastructure:logging'))
 
   jmhImplementation testFixtures(project(':infrastructure:bls'))

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySync.java
@@ -116,7 +116,7 @@ public class DasCustodySync implements SlotEventsChannel {
                 addPendingRequest(missingColumn);
               }
 
-              if (missingColumnsToRequest.isEmpty()) {
+              if (missingColumnsToRequest.size() < newRequestCount) {
                 coolDownTillNextSlot = true;
               }
 

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
@@ -13,11 +13,19 @@
 
 package tech.pegasys.teku.statetransition.datacolumns;
 
+import static java.time.Duration.ofMillis;
+import static java.time.Duration.ofMinutes;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
@@ -26,7 +34,9 @@ import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSi
 import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
+import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnSidecarRetriever;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnSidecarRetrieverStub;
+import tech.pegasys.teku.statetransition.datacolumns.retriever.DelayedDataColumnSidecarRetriever;
 
 @SuppressWarnings("JavaCase")
 public class DasCustodySyncTest {
@@ -45,12 +55,19 @@ public class DasCustodySyncTest {
                           .custodyRequirement(2)
                           .minEpochsForDataColumnSidecarsRequests(64)));
 
-  final DataColumnSidecarRetrieverStub retrieverStub = new DataColumnSidecarRetrieverStub();
-  final DasCustodyStand custodyStand = DasCustodyStand.builder(spec).build();
+  final DasCustodyStand custodyStand =
+      DasCustodyStand.builder(spec)
+          .withAsyncDb(ofMillis(1))
+          .withAsyncBlockResolver(ofMillis(2))
+          .build();
   final int maxSyncRequests = 32;
   final int minSyncRequests = 8;
+  final DataColumnSidecarRetrieverStub retrieverStub = new DataColumnSidecarRetrieverStub();
+  final DataColumnSidecarRetriever asyncRetriever =
+      new DelayedDataColumnSidecarRetriever(
+          retrieverStub, custodyStand.stubAsyncRunner, ofMillis(0));
   final DasCustodySync dasCustodySync =
-      new DasCustodySync(custodyStand.custody, retrieverStub, maxSyncRequests, minSyncRequests);
+      new DasCustodySync(custodyStand.custody, asyncRetriever, maxSyncRequests, minSyncRequests);
 
   final int epochLength = spec.slotsPerEpoch(UInt64.ZERO);
 
@@ -60,9 +77,13 @@ public class DasCustodySyncTest {
     custodyStand.subscribeToSlotEvents(dasCustodySync);
     dasCustodySync.start();
 
+    advanceTimeGraduallyUntilAllDone();
+
     printAndResetStats();
 
     custodyStand.setCurrentSlot(5);
+
+    advanceTimeGraduallyUntilAllDone();
 
     printAndResetStats();
     assertThat(retrieverStub.requests).isEmpty();
@@ -71,8 +92,12 @@ public class DasCustodySyncTest {
     custodyStand.blockResolver.addBlock(block_1.getMessage());
     custodyStand.setCurrentSlot(6);
 
+    advanceTimeGraduallyUntilAllDone();
+
     printAndResetStats();
     assertThat(retrieverStub.requests).isNotEmpty();
+
+    advanceTimeGraduallyUntilAllDone();
 
     custodyStand.setCurrentSlot(7);
 
@@ -85,7 +110,6 @@ public class DasCustodySyncTest {
     for (int slot = 0; slot <= startSlot; slot++) {
       addBlockAndSidecars(slot);
     }
-
     printAndResetStats();
 
     // on start we have 1000 uncustodied slots
@@ -93,6 +117,7 @@ public class DasCustodySyncTest {
     custodyStand.subscribeToSlotEvents(dasCustodySync);
     dasCustodySync.start();
 
+    advanceTimeGraduallyUntilAllDone();
     printAndResetStats();
 
     for (int slot = startSlot + 1; slot <= startSlot + 1000; slot++) {
@@ -102,6 +127,7 @@ public class DasCustodySyncTest {
         int epoch = slot / epochLength;
         custodyStand.setFinalizedEpoch(epoch - 2);
       }
+      advanceTimeGraduallyUntilAllDone();
     }
 
     assertThat(custodyStand.db.getDbReadCounter().get() / 1000)
@@ -113,12 +139,16 @@ public class DasCustodySyncTest {
 
     custodyStand.incCurrentSlot(10);
 
+    advanceTimeGraduallyUntilAllDone();
     printAndResetStats();
 
     List<DataColumnSlotAndIdentifier> missingColumns =
-        custodyStand.custody.retrieveMissingColumns().toList().join();
+        await(custodyStand.custody.retrieveMissingColumns().toList());
     assertThat(missingColumns).isEmpty();
     assertAllCustodyColumnsPresent();
+
+    assertThat(await(custodyStand.db.getFirstCustodyIncompleteSlot()))
+        .hasValueSatisfying(slot -> assertThat(slot.intValue()).isGreaterThan(1900));
   }
 
   @Test
@@ -134,6 +164,7 @@ public class DasCustodySyncTest {
     custodyStand.subscribeToSlotEvents(dasCustodySync);
     dasCustodySync.start();
 
+    advanceTimeGraduallyUntilAllDone();
     printAndResetStats();
 
     for (int slot = startSlot + 1; slot <= startSlot + 1000; slot++) {
@@ -143,6 +174,7 @@ public class DasCustodySyncTest {
         int epoch = slot / epochLength;
         custodyStand.setFinalizedEpoch(epoch - 2);
       }
+      advanceTimeGraduallyUntilAllDone();
     }
 
     assertThat(custodyStand.db.getDbReadCounter().get() / 1000)
@@ -154,10 +186,11 @@ public class DasCustodySyncTest {
 
     custodyStand.incCurrentSlot(10);
 
+    advanceTimeGraduallyUntilAllDone();
     printAndResetStats();
 
     List<DataColumnSlotAndIdentifier> missingColumns =
-        custodyStand.custody.retrieveMissingColumns().toList().join();
+        await(custodyStand.custody.retrieveMissingColumns().toList());
     assertThat(missingColumns).isEmpty();
     assertAllCustodyColumnsPresent();
   }
@@ -170,6 +203,7 @@ public class DasCustodySyncTest {
     custodyStand.subscribeToSlotEvents(dasCustodySync);
     dasCustodySync.start();
 
+    advanceTimeGraduallyUntilAllDone();
     printAndResetStats();
 
     for (int slot = startSlot + 1; slot <= startSlot + 1000; slot++) {
@@ -179,6 +213,7 @@ public class DasCustodySyncTest {
         int epoch = slot / epochLength;
         custodyStand.setFinalizedEpoch(epoch - 2);
       }
+      advanceTimeGraduallyUntilAllDone();
     }
 
     assertThat(custodyStand.db.getDbReadCounter().get() / 1000)
@@ -189,11 +224,12 @@ public class DasCustodySyncTest {
     printAndResetStats();
 
     custodyStand.incCurrentSlot(10);
+    advanceTimeGraduallyUntilAllDone();
 
     printAndResetStats();
 
     List<DataColumnSlotAndIdentifier> missingColumns =
-        custodyStand.custody.retrieveMissingColumns().toList().join();
+        await(custodyStand.custody.retrieveMissingColumns().toList());
     assertThat(missingColumns).isEmpty();
     assertAllCustodyColumnsPresent();
   }
@@ -209,11 +245,13 @@ public class DasCustodySyncTest {
     custodyStand.subscribeToSlotEvents(dasCustodySync);
     dasCustodySync.start();
 
+    advanceTimeGraduallyUntilAllDone();
     printAndResetStats();
 
     for (int slot = 1; slot <= 1000; slot++) {
       addBlockAndSidecars(slot);
       custodyStand.incCurrentSlot(1);
+      advanceTimeGraduallyUntilAllDone();
     }
 
     assertThat(custodyStand.db.getDbReadCounter().get() / 1000)
@@ -225,10 +263,11 @@ public class DasCustodySyncTest {
 
     custodyStand.incCurrentSlot(10);
 
+    advanceTimeGraduallyUntilAllDone();
     printAndResetStats();
 
     List<DataColumnSlotAndIdentifier> missingColumns =
-        custodyStand.custody.retrieveMissingColumns().toList().join();
+        await(custodyStand.custody.retrieveMissingColumns().toList());
     assertThat(missingColumns).isEmpty();
     assertAllCustodyColumnsPresent();
   }
@@ -255,11 +294,9 @@ public class DasCustodySyncTest {
               Collection<UInt64> colIndexes = custodyStand.getCustodyColumnIndexes(uSlot);
               for (UInt64 colIndex : colIndexes) {
                 Optional<DataColumnSidecar> maybeSidecar =
-                    custodyStand
-                        .custody
-                        .getCustodyDataColumnSidecar(
-                            new DataColumnIdentifier(block.getRoot(), colIndex))
-                        .join();
+                    await(
+                        custodyStand.custody.getCustodyDataColumnSidecar(
+                            new DataColumnIdentifier(block.getRoot(), colIndex)));
                 assertThat(maybeSidecar)
                     .isPresent()
                     .hasValueSatisfying(
@@ -273,6 +310,28 @@ public class DasCustodySyncTest {
             }
           });
     }
+  }
+
+  private void advanceTimeGraduallyUntilAllDone() {
+    custodyStand.advanceTimeGraduallyUntilAllDone(ofMinutes(1));
+  }
+
+  private <T> T await(CompletableFuture<T> future) {
+    return await(future, ofMinutes(1));
+  }
+
+  private <T> T await(CompletableFuture<T> future, Duration maxWait) {
+    for (int i = 0; i < maxWait.toMillis(); i++) {
+      if (future.isDone()) {
+        try {
+          return future.get();
+        } catch (InterruptedException | ExecutionException e) {
+          throw new RuntimeException(e);
+        }
+      }
+      custodyStand.advanceTimeGradually(ofMillis(1));
+    }
+    throw new AssertionError("Timeout waiting for the future to complete");
   }
 
   private void printAndResetStats() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodySyncTest.java
@@ -22,10 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
@@ -14,16 +14,22 @@
 package tech.pegasys.teku.statetransition.datacolumns;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.time.Duration.ofMillis;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.assertj.core.api.Assertions;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
+import tech.pegasys.teku.infrastructure.async.StubAsyncRunner;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.SpecMilestone;
@@ -34,7 +40,9 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlock;
 import tech.pegasys.teku.spec.datastructures.blocks.blockbody.BeaconBlockBody;
 import tech.pegasys.teku.spec.datastructures.state.Checkpoint;
 import tech.pegasys.teku.spec.util.DataStructureUtil;
+import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
+import tech.pegasys.teku.statetransition.datacolumns.db.DelayedDasDb;
 import tech.pegasys.teku.storage.api.FinalizedCheckpointChannel;
 
 @SuppressWarnings("unused")
@@ -43,6 +51,9 @@ public class DasCustodyStand {
   public static Builder builder(Spec spec) {
     return new Builder().withSpec(spec);
   }
+
+  final StubTimeProvider stubTimeProvider = StubTimeProvider.withTimeInSeconds(0);
+  final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner(stubTimeProvider);
 
   public final Spec spec;
 
@@ -65,19 +76,39 @@ public class DasCustodyStand {
   private UInt64 currentSlot = UInt64.ZERO;
 
   public DasCustodyStand(
-      Spec spec, UInt64 currentSlot, UInt256 myNodeId, int totalCustodySubnetCount) {
+      Spec spec,
+      UInt64 currentSlot,
+      UInt256 myNodeId,
+      int totalCustodySubnetCount,
+      Optional<Duration> asyncDbDelay,
+      Optional<Duration> asyncBlockResolverDelay) {
     this.spec = spec;
     this.myNodeId = myNodeId;
     this.blockResolver = new CanonicalBlockResolverStub(spec);
+    CanonicalBlockResolver asyncBlockResolver =
+        asyncBlockResolverDelay
+            .map(
+                delay ->
+                    (CanonicalBlockResolver)
+                        new DelayedCanonicalBlockResolver(
+                            this.blockResolver, stubAsyncRunner, delay))
+            .orElse(this.blockResolver);
     this.config = SpecConfigEip7594.required(spec.forMilestone(SpecMilestone.EIP7594).getConfig());
     this.minCustodyPeriodSlotCalculator = MinCustodyPeriodSlotCalculator.createFromSpec(spec);
     this.db = new DataColumnSidecarDBStub();
-    this.dbAccessor = DataColumnSidecarDbAccessor.builder(db).spec(spec).build();
+    DataColumnSidecarDB asyncDb =
+        asyncDbDelay
+            .map(
+                dbDelay ->
+                    (DataColumnSidecarDB) new DelayedDasDb(this.db, stubAsyncRunner, dbDelay))
+            .orElse(this.db);
+
+    this.dbAccessor = DataColumnSidecarDbAccessor.builder(asyncDb).spec(spec).build();
 
     this.custody =
         new DataColumnSidecarCustodyImpl(
             spec,
-            blockResolver,
+            asyncBlockResolver,
             dbAccessor,
             minCustodyPeriodSlotCalculator,
             myNodeId,
@@ -93,7 +124,27 @@ public class DasCustodyStand {
     this.totalCustodySubnetCount = totalCustodySubnetCount;
   }
 
-  public SignedBeaconBlock createBlockWithBlobs(int slot) {
+  public void advanceTimeGradually(Duration delta) {
+    for (int i = 0; i < delta.toMillis(); i++) {
+      stubTimeProvider.advanceTimeBy(ofMillis(1));
+      stubAsyncRunner.executeDueActionsRepeatedly();
+    }
+  }
+
+  public void advanceTimeGraduallyUntilAllDone(Duration maxAdvancePeriod) {
+    for (int i = 0; i < maxAdvancePeriod.toMillis(); i++) {
+      if (!stubAsyncRunner.hasDelayedActions()) {
+        return;
+      }
+      stubTimeProvider.advanceTimeBy(ofMillis(1));
+      stubAsyncRunner.executeDueActionsRepeatedly();
+    }
+    throw new AssertionError(
+        "There are still scheduled tasks after maxAdvancePeriod: " + maxAdvancePeriod);
+  }
+
+
+    public SignedBeaconBlock createBlockWithBlobs(int slot) {
     return createBlock(slot, 3);
   }
 
@@ -181,6 +232,8 @@ public class DasCustodyStand {
     private UInt64 currentSlot = UInt64.ZERO;
     private UInt256 myNodeId = UInt256.ONE;
     private Integer totalCustodySubnetCount;
+    private Optional<Duration> asyncDbDelay = Optional.empty();
+    private Optional<Duration> asyncBlockResolverDelay = Optional.empty();
 
     public Builder withSpec(Spec spec) {
       this.spec = spec;
@@ -202,6 +255,16 @@ public class DasCustodyStand {
       return this;
     }
 
+    public Builder withAsyncDb(Duration asyncDbDelay) {
+      this.asyncDbDelay = Optional.ofNullable(asyncDbDelay);
+      return this;
+    }
+
+    public Builder withAsyncBlockResolver(Duration asyncBlockResolverDelay) {
+      this.asyncBlockResolverDelay = Optional.ofNullable(asyncBlockResolverDelay);
+      return this;
+    }
+
     public DasCustodyStand build() {
       if (totalCustodySubnetCount == null) {
         checkNotNull(spec);
@@ -209,7 +272,13 @@ public class DasCustodyStand {
             SpecConfigEip7594.required(spec.forMilestone(SpecMilestone.EIP7594).getConfig());
         totalCustodySubnetCount = configEip7594.getCustodyRequirement();
       }
-      return new DasCustodyStand(spec, currentSlot, myNodeId, totalCustodySubnetCount);
+      return new DasCustodyStand(
+          spec,
+          currentSlot,
+          myNodeId,
+          totalCustodySubnetCount,
+          asyncDbDelay,
+          asyncBlockResolverDelay);
     }
   }
 }

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DasCustodyStand.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
-import org.assertj.core.api.Assertions;
 import tech.pegasys.teku.bls.BLSPublicKey;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.ethereum.events.SlotEventsChannel;
@@ -143,8 +142,7 @@ public class DasCustodyStand {
         "There are still scheduled tasks after maxAdvancePeriod: " + maxAdvancePeriod);
   }
 
-
-    public SignedBeaconBlock createBlockWithBlobs(int slot) {
+  public SignedBeaconBlock createBlockWithBlobs(int slot) {
     return createBlock(slot, 3);
   }
 

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DelayedCanonicalBlockResolver.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DelayedCanonicalBlockResolver.java
@@ -1,0 +1,36 @@
+package tech.pegasys.teku.statetransition.datacolumns;
+
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class DelayedCanonicalBlockResolver implements CanonicalBlockResolver {
+
+  private final CanonicalBlockResolver delegate;
+  private final AsyncRunner asyncRunner;
+  private Duration delay;
+
+  public DelayedCanonicalBlockResolver(CanonicalBlockResolver delegate, AsyncRunner asyncRunner, Duration delay) {
+    this.delegate = delegate;
+    this.asyncRunner = asyncRunner;
+    this.delay = delay;
+  }
+
+  public void setDelay(Duration delay) {
+    this.delay = delay;
+  }
+
+  private <T> SafeFuture<T> delay(Supplier<SafeFuture<T>> futSupplier) {
+    return asyncRunner.getDelayedFuture(delay).thenCompose(__ -> futSupplier.get());
+  }
+
+  @Override
+  public SafeFuture<Optional<BeaconBlock>> getBlockAtSlot(UInt64 slot) {
+    return delay(() -> delegate.getBlockAtSlot(slot));
+  }
+}

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DelayedCanonicalBlockResolver.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/DelayedCanonicalBlockResolver.java
@@ -1,13 +1,25 @@
-package tech.pegasys.teku.statetransition.datacolumns;
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 
-import tech.pegasys.teku.infrastructure.async.AsyncRunner;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.infrastructure.unsigned.UInt64;
-import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
+package tech.pegasys.teku.statetransition.datacolumns;
 
 import java.time.Duration;
 import java.util.Optional;
 import java.util.function.Supplier;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blocks.BeaconBlock;
 
 public class DelayedCanonicalBlockResolver implements CanonicalBlockResolver {
 
@@ -15,7 +27,8 @@ public class DelayedCanonicalBlockResolver implements CanonicalBlockResolver {
   private final AsyncRunner asyncRunner;
   private Duration delay;
 
-  public DelayedCanonicalBlockResolver(CanonicalBlockResolver delegate, AsyncRunner asyncRunner, Duration delay) {
+  public DelayedCanonicalBlockResolver(
+      CanonicalBlockResolver delegate, AsyncRunner asyncRunner, Duration delay) {
     this.delegate = delegate;
     this.asyncRunner = asyncRunner;
     this.delay = delay;

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DelayedDataColumnSidecarRetriever.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DelayedDataColumnSidecarRetriever.java
@@ -1,0 +1,33 @@
+package tech.pegasys.teku.statetransition.datacolumns.retriever;
+
+import java.time.Duration;
+import java.util.function.Supplier;
+import tech.pegasys.teku.infrastructure.async.AsyncRunner;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
+import tech.pegasys.teku.statetransition.datacolumns.DataColumnSlotAndIdentifier;
+
+public class DelayedDataColumnSidecarRetriever implements DataColumnSidecarRetriever {
+  private final DataColumnSidecarRetriever delegate;
+  private final AsyncRunner asyncRunner;
+  private Duration delay;
+
+  public DelayedDataColumnSidecarRetriever(DataColumnSidecarRetriever delegate, AsyncRunner asyncRunner, Duration delay) {
+    this.delegate = delegate;
+    this.asyncRunner = asyncRunner;
+    this.delay = delay;
+  }
+
+  public void setDelay(Duration delay) {
+    this.delay = delay;
+  }
+
+  private <T> SafeFuture<T> delay(Supplier<SafeFuture<T>> futSupplier) {
+    return asyncRunner.getDelayedFuture(delay).thenCompose(__ -> futSupplier.get());
+  }
+
+  @Override
+  public SafeFuture<DataColumnSidecar> retrieve(DataColumnSlotAndIdentifier columnId) {
+    return delay(() -> delegate.retrieve(columnId));
+  }
+}

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DelayedDataColumnSidecarRetriever.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DelayedDataColumnSidecarRetriever.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
 import java.time.Duration;
@@ -12,7 +25,8 @@ public class DelayedDataColumnSidecarRetriever implements DataColumnSidecarRetri
   private final AsyncRunner asyncRunner;
   private Duration delay;
 
-  public DelayedDataColumnSidecarRetriever(DataColumnSidecarRetriever delegate, AsyncRunner asyncRunner, Duration delay) {
+  public DelayedDataColumnSidecarRetriever(
+      DataColumnSidecarRetriever delegate, AsyncRunner asyncRunner, Duration delay) {
     this.delegate = delegate;
     this.asyncRunner = asyncRunner;
     this.delay = delay;

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncIteratorCallback.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncIteratorCallback.java
@@ -32,7 +32,12 @@ interface AsyncIteratorCallback<T> {
    */
   SafeFuture<Boolean> onNext(T t);
 
-  /** Called when the stream is complete. No other calls are expected after this call */
+  /**
+   * Called when the stream is complete. No other calls are expected after this call
+   *
+   * <p>An implementation MUST NOT call this method prior to {@link SafeFuture<Boolean>} returned
+   * from the last {@link #onNext(Object)} call is completed.
+   */
   void onComplete();
 
   /** Called when upstream error happened Basically no other calls are expected after this */

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/FutureAsyncIteratorImpl.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/FutureAsyncIteratorImpl.java
@@ -27,10 +27,7 @@ class FutureAsyncIteratorImpl<T> extends AsyncIterator<T> {
   @Override
   public void iterate(AsyncIteratorCallback<T> callback) {
     future.finish(
-        succ -> {
-          callback.onNext(succ).ifExceptionGetsHereRaiseABug();
-          callback.onComplete();
-        },
+        succ -> callback.onNext(succ).finish(__ -> callback.onComplete(), callback::onError),
         callback::onError);
   }
 }

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamTest.java
@@ -17,10 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamTest.java
@@ -17,6 +17,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -69,6 +73,31 @@ public class AsyncStreamTest {
     assertThat(collector).containsExactly(0, 20, 40, 100, 120, 140, 200, 220, 240, 300);
     assertThat(listPromise)
         .isCompletedWithValue(List.of(0, 20, 40, 100, 120, 140, 200, 220, 240, 300));
+  }
+
+  @Test
+  void mapAsyncTest() throws Exception {
+    int listSize = 100;
+    SafeFuture<Void> launchFuture = new SafeFuture<>();
+    List<SafeFuture<Integer>> futures =
+        Stream.generate(() -> new SafeFuture<Integer>()).limit(listSize).toList();
+
+    SafeFuture<List<Integer>> listFuture =
+        AsyncStream.create(launchFuture)
+            .flatMap(
+                __ -> {
+                  Stream<Integer> idxStream = IntStream.range(0, futures.size()).boxed();
+                  return AsyncStream.create(idxStream).mapAsync(futures::get);
+                })
+            .toList();
+
+    launchFuture.complete(null);
+    for (int i = 0; i < futures.size(); i++) {
+      futures.get(i).complete(i);
+    }
+
+    assertThat(listFuture.get(1, TimeUnit.SECONDS))
+        .containsExactlyElementsOf(IntStream.range(0, listSize).boxed().toList());
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Fixes Item 1 in the issue #135 

- Fix the `AsyncStream` issue which resulted in an empty stream for `DataColumnSidecarCustodyImpl.retrievePotentiallyIncompleteSlotCustodies()` and thus both sync and advancing `firstNonFinalizedSlot` didn't work
- Add an `AsyncStreamTest` case which reproduces the issue 
- `DasCustodySyncTest`: make db, blockResolver and retriever async with some delay to better emulate sync in a wild. Without async the above issue was not reproducible
- Suppress extra `DasCustodySync.fillUp()` call which appeared with the above async testing

