### PR TITLE
Retry batch sync when receiving blocks and failing DAS during import

### DIFF
--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchImporter.java
@@ -90,6 +90,8 @@ public class BatchImporter {
                   return BatchImportResult.IMPORTED_ALL_BLOCKS;
                 } else if (lastBlockImportResult.hasFailedExecutingExecutionPayload()) {
                   return BatchImportResult.SERVICE_OFFLINE;
+                } else if (lastBlockImportResult.isDataNotYetAvailable()) {
+                  return BatchImportResult.DATA_NOT_YET_AVAILABLE;
                 }
                 LOG.debug(
                     "Failed to import batch {}: {}",
@@ -143,7 +145,8 @@ public class BatchImporter {
   public enum BatchImportResult {
     IMPORTED_ALL_BLOCKS,
     IMPORT_FAILED,
-    SERVICE_OFFLINE;
+    SERVICE_OFFLINE,
+    DATA_NOT_YET_AVAILABLE;
 
     public boolean isFailure() {
       return this == IMPORT_FAILED;

--- a/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchSync.java
+++ b/beacon/sync/src/main/java/tech/pegasys/teku/beacon/sync/forward/multipeer/BatchSync.java
@@ -42,7 +42,7 @@ import tech.pegasys.teku.storage.client.RecentChainData;
 /** Manages the sync process to reach a finalized chain. */
 public class BatchSync implements Sync {
   private static final Logger LOG = LogManager.getLogger();
-  private static final Duration PAUSE_ON_SERVICE_OFFLINE = Duration.ofSeconds(5);
+  private static final Duration PAUSE_ON_SERVICE_OFFLINE_OR_DAS_CHECK = Duration.ofSeconds(5);
 
   private final EventThread eventThread;
   private final AsyncRunner asyncRunner;
@@ -402,7 +402,8 @@ public class BatchSync implements Sync {
         LOG.debug("Marking batch {} as invalid because it extends from an invalid block", batch);
         batch.markAsInvalid();
       }
-    } else if (result == BatchImportResult.SERVICE_OFFLINE) {
+    } else if (result == BatchImportResult.SERVICE_OFFLINE
+        || result == BatchImportResult.DATA_NOT_YET_AVAILABLE) {
       if (!scheduledProgressSync) {
         LOG.warn("Unable to import blocks because execution client is offline.");
         asyncRunner
@@ -413,7 +414,7 @@ public class BatchSync implements Sync {
                           scheduledProgressSync = false;
                           progressSync();
                         }),
-                PAUSE_ON_SERVICE_OFFLINE)
+                PAUSE_ON_SERVICE_OFFLINE_OR_DAS_CHECK)
             .ifExceptionGetsHereRaiseABug();
         scheduledProgressSync = true;
       }

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/BlockImportResult.java
@@ -118,6 +118,9 @@ public interface BlockImportResult {
   default boolean hasFailedExecutingExecutionPayload() {
     return false;
   }
+  default boolean isDataNotYetAvailable() {
+    return false;
+  }
 
   default void markAsCanonical() {
     throw new UnsupportedOperationException(

--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/FailedBlockImportResult.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/logic/common/statetransition/results/FailedBlockImportResult.java
@@ -56,6 +56,11 @@ public class FailedBlockImportResult implements BlockImportResult {
   }
 
   @Override
+  public boolean isDataNotYetAvailable() {
+    return failureReason == FailureReason.FAILED_DATA_AVAILABILITY_CHECK_NOT_AVAILABLE;
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("failureReason", failureReason)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

This resolves clause 2 in the issue #135

When receiving a batch of blocks and fail to improt them due to DAS fail we will be doing similar to the `SERVICE_OFFLINE` situation when execution engine fails to validate payload but will probably do it later. 

This doesn't look like a perfect solution, but for now it looks better than ban a peer blaming it as it sends _invalid_ blocks

