### PR TITLE
Fix DasLongPollCustody issue

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustody.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustody.java
@@ -127,7 +127,7 @@ public class DasLongPollCustody implements UpdatableDataColumnSidecarCustody, Sl
         final SafeFuture<Optional<DataColumnSidecar>> promise) {
       final boolean cancelImmediately;
       synchronized (this) {
-        if (columnId.slot().isLessThanOrEqualTo(noWaitSlot)) {
+        if (columnId.slot().isLessThan(noWaitSlot)) {
           cancelImmediately = true;
         } else {
           clearCancelledPendingRequests();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
@@ -171,7 +171,6 @@ public class DasLongPollCustodyTest {
     assertThat(fRet0).isCompletedWithValue(Optional.empty());
   }
 
-
   @Test
   void testOptionalEmptyIsReturnedOnTimeout() {
     SafeFuture<Optional<DataColumnSidecar>> fRet0 =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
@@ -156,6 +156,23 @@ public class DasLongPollCustodyTest {
   }
 
   @Test
+  void testEmptyIsNotRetrunedImmediatelyAtBeginningOfCurrentSlot() {
+    custody.onSlot(UInt64.valueOf(9));
+    advanceTimeGradually(currentSlotTimeout.plusMillis(100));
+
+    custody.onSlot(UInt64.valueOf(10));
+    SafeFuture<Optional<DataColumnSidecar>> fRet0 =
+        custody.getCustodyDataColumnSidecar(columnId10_0);
+
+    advanceTimeGradually(ofMillis(100));
+    assertThat(fRet0).isNotDone();
+
+    advanceTimeGradually(currentSlotTimeout);
+    assertThat(fRet0).isCompletedWithValue(Optional.empty());
+  }
+
+
+  @Test
   void testOptionalEmptyIsReturnedOnTimeout() {
     SafeFuture<Optional<DataColumnSidecar>> fRet0 =
         custody.getCustodyDataColumnSidecar(columnId10_0);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/Consensys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

Fix the issue when long poll query retrunes immediately at the beginning of the current slot 