### PR TITLE
Fix the RecoveringSidecarRetriever case when there are more than one block for the same slot in DB

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarCoreDB.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/db/DataColumnSidecarCoreDB.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 
 interface DataColumnSidecarCoreDB {
@@ -27,6 +28,14 @@ interface DataColumnSidecarCoreDB {
   SafeFuture<Optional<DataColumnSidecar>> getSidecar(DataColumnSlotAndIdentifier identifier);
 
   SafeFuture<List<DataColumnSlotAndIdentifier>> getColumnIdentifiers(UInt64 slot);
+
+  default SafeFuture<List<DataColumnSlotAndIdentifier>> getColumnIdentifiers(
+      SlotAndBlockRoot blockId) {
+    return getColumnIdentifiers(blockId.getSlot())
+        .thenApply(
+            ids ->
+                ids.stream().filter(id -> id.blockRoot().equals(blockId.getBlockRoot())).toList());
+  }
 
   // update
   SafeFuture<Void> addSidecar(DataColumnSidecar sidecar);

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetriever.java
@@ -140,7 +140,7 @@ public class RecoveringSidecarRetriever implements DataColumnSidecarRetriever {
         recoveryEntry.block.getSlot(),
         recoveryEntry.block.getRoot());
     sidecarDB
-        .getColumnIdentifiers(block.getSlot())
+        .getColumnIdentifiers(block.getSlotAndBlockRoot())
         .thenCompose(
             dataColumnIdentifiers ->
                 SafeFuture.collectAll(

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -43,7 +43,7 @@ import tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarDBStub;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDB;
 import tech.pegasys.teku.statetransition.datacolumns.db.DataColumnSidecarDbAccessor;
 
-@SuppressWarnings("FutureReturnValueIgnored")
+@SuppressWarnings({"FutureReturnValueIgnored", "JavaCase"})
 public class RecoveringSidecarRetrieverTest {
 
   final StubAsyncRunner stubAsyncRunner = new StubAsyncRunner();

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/RecoveringSidecarRetrieverTest.java
@@ -134,6 +134,59 @@ public class RecoveringSidecarRetrieverTest {
   }
 
   @Test
+  void testMoreThanOneBlockWithBlobsOnSameSlot() throws Exception {
+    int blobCount = 1;
+    int columnsInDbCount = 13;
+
+    DataColumnSidecarRetrieverStub delegateRetriever = new DataColumnSidecarRetrieverStub();
+    RecoveringSidecarRetriever recoverRetrievr =
+        new RecoveringSidecarRetriever(
+            delegateRetriever,
+            kzg,
+            miscHelpers,
+            schemaDefinitions,
+            blockResolver,
+            dbAccessor,
+            stubAsyncRunner,
+            Duration.ofSeconds(1),
+            128);
+    List<Blob> blobs_10_0 =
+        Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
+    BeaconBlock block_10_0 = blockResolver.addBlock(10, blobCount);
+    List<DataColumnSidecar> sidecars_10_0 =
+        miscHelpers.constructDataColumnSidecars(createSigned(block_10_0), blobs_10_0, kzg);
+    sidecars_10_0.forEach(db::addSidecar);
+
+    List<Blob> blobs_10_1 =
+        Stream.generate(dataStructureUtil::randomValidBlob).limit(blobCount).toList();
+    BeaconBlock block_10_1 = blockResolver.addBlock(10, blobCount);
+    List<DataColumnSidecar> sidecars_10_1 =
+        miscHelpers.constructDataColumnSidecars(createSigned(block_10_1), blobs_10_1, kzg);
+    sidecars_10_1.stream().limit(columnsInDbCount).forEach(db::addSidecar);
+
+    DataColumnSlotAndIdentifier id0 = createId(block_10_1, 100);
+    SafeFuture<DataColumnSidecar> res0 = recoverRetrievr.retrieve(id0);
+
+    assertThat(delegateRetriever.requests).hasSize(1);
+
+    recoverRetrievr.maybeInitiateRecovery(id0, res0);
+    assertThat(delegateRetriever.requests).hasSize(1 + columnCount - columnsInDbCount);
+
+    delegateRetriever.requests.stream()
+        .skip(50)
+        .limit(columnCount / 2 - columnsInDbCount)
+        .forEach(
+            req -> {
+              req.promise().complete(sidecars_10_1.get(req.columnId().columnIndex().intValue()));
+            });
+
+    stubAsyncRunner.executeQueuedActions();
+
+    assertThat(res0).isCompletedWithValue(sidecars_10_1.get(100));
+    assertThat(delegateRetriever.requests).allMatch(r -> r.promise().isDone());
+  }
+
+  @Test
   void cancellingRequestShouldStopRecovery() throws Exception {
     int blobCount = 3;
     int columnsInDbCount = 3;


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

- Fix the `RecoveringSidecarRetriever` case when there are more than one block for the same slot in DB
- Add the test reproducing the issue 
