### PR TITLE
Use AsyncStream for data column req/resp interfaces  

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/BatchDataColumnsByRangeReqResp.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/BatchDataColumnsByRangeReqResp.java
@@ -11,26 +11,19 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.infrastructure.async.stream;
+package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
-import java.util.function.Predicate;
+import java.util.List;
+import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 
-class FilteringIteratorCallback<T> extends AbstractDelegatingIteratorCallback<T, T> {
+public interface BatchDataColumnsByRangeReqResp {
 
-  private final Predicate<T> filter;
+  AsyncStream<DataColumnSidecar> requestDataColumnSidecarsByRange(
+      UInt256 nodeId, UInt64 startSlot, int slotCount, List<UInt64> columnIndexes);
 
-  protected FilteringIteratorCallback(AsyncIteratorCallback<T> delegate, Predicate<T> filter) {
-    super(delegate);
-    this.filter = filter;
-  }
-
-  @Override
-  public SafeFuture<Boolean> onNext(T t) {
-    if (filter.test(t)) {
-      return delegate.onNext(t);
-    } else {
-      return TRUE_FUTURE;
-    }
-  }
+  int getCurrentRequestLimit(UInt256 nodeId);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/BatchDataColumnsByRangeReqResp.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/BatchDataColumnsByRangeReqResp.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
 import java.util.List;
 import org.apache.tuweni.units.bigints.UInt256;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/BatchDataColumnsByRootReqResp.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/BatchDataColumnsByRootReqResp.java
@@ -15,7 +15,6 @@ package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
 import java.util.List;
 import org.apache.tuweni.units.bigints.UInt256;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/BatchDataColumnsByRootReqResp.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/BatchDataColumnsByRootReqResp.java
@@ -11,23 +11,19 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.infrastructure.async.stream;
+package tech.pegasys.teku.statetransition.datacolumns.retriever;
 
-import java.util.concurrent.CompletionStage;
+import java.util.List;
+import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
+import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
+import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 
-class FutureAsyncIteratorImpl<T> extends AsyncIterator<T> {
+public interface BatchDataColumnsByRootReqResp {
 
-  private final SafeFuture<T> future;
+  AsyncStream<DataColumnSidecar> requestDataColumnSidecarsByRoot(
+      UInt256 nodeId, List<DataColumnIdentifier> columnIdentifiers);
 
-  FutureAsyncIteratorImpl(CompletionStage<T> future) {
-    this.future = SafeFuture.of(future);
-  }
-
-  @Override
-  public void iterate(AsyncStreamHandler<T> callback) {
-    future.finish(
-        succ -> callback.onNext(succ).finish(__ -> callback.onComplete(), callback::onError),
-        callback::onError);
-  }
+  int getCurrentRequestLimit(UInt256 nodeId);
 }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
@@ -18,19 +18,24 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
+import tech.pegasys.teku.infrastructure.async.stream.AsyncStreamHandler;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
 
 public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
   private static final Logger LOG = LogManager.getLogger("das-nyota");
 
-  private final BatchDataColumnReqResp batchRpc;
+  private final BatchDataColumnsByRootReqResp batchRpc;
 
-  public DataColumnReqRespBatchingImpl(BatchDataColumnReqResp batchRpc) {
+  public DataColumnReqRespBatchingImpl(BatchDataColumnsByRootReqResp batchRpc) {
     this.batchRpc = batchRpc;
   }
 
@@ -68,42 +73,59 @@ public class DataColumnReqRespBatchingImpl implements DataColumnReqResp {
         nodeRequests.size(),
         "0x..." + nodeId.toHexString().substring(58),
         nodeRequests.hashCode());
-    SafeFuture<List<DataColumnSidecar>> response =
-        SafeFuture.of(
-            () ->
-                batchRpc.requestDataColumnSidecar(
-                    nodeId, nodeRequests.stream().map(e -> e.columnIdentifier).toList()));
+    AsyncStream<DataColumnSidecar> response =
+        batchRpc.requestDataColumnSidecarsByRoot(
+            nodeId, nodeRequests.stream().map(e -> e.columnIdentifier).toList());
 
-    response.finish(
-        resp -> {
-          LOG.info(
-              "[nyota] Response batch of {} from {}, hash={}",
-              resp.size(),
-              "0x..." + nodeId.toHexString().substring(58),
-              nodeRequests.hashCode());
-          Map<DataColumnIdentifier, DataColumnSidecar> byIds = new HashMap<>();
-          for (DataColumnSidecar sidecar : resp) {
-            byIds.put(DataColumnIdentifier.createFromSidecar(sidecar), sidecar);
-          }
-          for (RequestEntry nodeRequest : nodeRequests) {
-            DataColumnSidecar maybeResponse = byIds.get(nodeRequest.columnIdentifier);
-            if (maybeResponse != null) {
-              nodeRequest.promise().complete(maybeResponse);
+    response.consume(
+        new AsyncStreamHandler<>() {
+          private final AtomicInteger count = new AtomicInteger();
+          private final Map<DataColumnIdentifier, RequestEntry> requestsNyColumnId =
+              nodeRequests.stream()
+                  .collect(Collectors.toMap(RequestEntry::columnIdentifier, req -> req));
+
+          @Override
+          public SafeFuture<Boolean> onNext(DataColumnSidecar dataColumnSidecar) {
+            DataColumnIdentifier colId = DataColumnIdentifier.createFromSidecar(dataColumnSidecar);
+            RequestEntry request = requestsNyColumnId.get(colId);
+            if (request == null) {
+              return SafeFuture.failedFuture(
+                  new IllegalArgumentException(
+                      "Responded data column was not requested: " + colId));
             } else {
-              nodeRequest.promise().completeExceptionally(new DasColumnNotAvailableException());
+              request.promise().complete(dataColumnSidecar);
+              count.incrementAndGet();
+              return TRUE_FUTURE;
             }
           }
-        },
-        err ->
+
+          @Override
+          public void onComplete() {
+            LOG.info(
+                "[nyota] Response batch of {} from {}, hash={}",
+                count,
+                "0x..." + nodeId.toHexString().substring(58),
+                nodeRequests.hashCode());
+            nodeRequests.stream()
+                .filter(req -> !req.promise().isDone())
+                .forEach(
+                    req ->
+                        req.promise().completeExceptionally(new DasColumnNotAvailableException()));
+          }
+
+          @Override
+          public void onError(Throwable err) {
             nodeRequests.forEach(
                 e -> {
                   LOG.info(
                       "[nyota] Error batch from {}, hash={}, err: {}",
-                      nodeId.mod(65536).toHexString(),
+                      "0x..." + nodeId.toHexString().substring(58),
                       nodeRequests.hashCode(),
                       e.toString());
                   e.promise().completeExceptionally(err);
-                }));
+                });
+          }
+        });
   }
 
   @Override

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DataColumnReqRespBatchingImpl.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.units.bigints.UInt256;

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AbstractDelegatingStreamHandler.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AbstractDelegatingStreamHandler.java
@@ -11,18 +11,23 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package tech.pegasys.teku.statetransition.datacolumns.retriever;
+package tech.pegasys.teku.infrastructure.async.stream;
 
-import java.util.List;
-import org.apache.tuweni.units.bigints.UInt256;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
-import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
-import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
+abstract class AbstractDelegatingStreamHandler<S, T> implements AsyncStreamHandler<T> {
 
-public interface BatchDataColumnReqResp {
+  protected final AsyncStreamHandler<S> delegate;
 
-  SafeFuture<List<DataColumnSidecar>> requestDataColumnSidecar(
-      UInt256 nodeId, List<DataColumnIdentifier> columnIdentifiers);
+  protected AbstractDelegatingStreamHandler(AsyncStreamHandler<S> delegate) {
+    this.delegate = delegate;
+  }
 
-  int getCurrentRequestLimit(UInt256 nodeId);
+  @Override
+  public void onComplete() {
+    delegate.onComplete();
+  }
+
+  @Override
+  public void onError(Throwable t) {
+    delegate.onError(t);
+  }
 }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncIterator.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncIterator.java
@@ -15,8 +15,6 @@ package tech.pegasys.teku.infrastructure.async.stream;
 
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.stream.Collector;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 abstract class AsyncIterator<T> implements AsyncStream<T> {
 
@@ -29,8 +27,7 @@ abstract class AsyncIterator<T> implements AsyncStream<T> {
     return OperationAsyncIterator.create(
         this,
         sourceCallback ->
-            new MapStreamHandler<>(
-                new FlattenStreamHandler<>(sourceCallback), toIteratorMapper));
+            new MapStreamHandler<>(new FlattenStreamHandler<>(sourceCallback), toIteratorMapper));
   }
 
   @Override

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncIterator.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncIterator.java
@@ -20,7 +20,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 abstract class AsyncIterator<T> implements AsyncStream<T> {
 
-  abstract void iterate(AsyncIteratorCallback<T> callback);
+  abstract void iterate(AsyncStreamHandler<T> callback);
 
   @Override
   public <R> AsyncIterator<R> flatMap(Function<T, AsyncStream<R>> toStreamMapper) {
@@ -29,30 +29,30 @@ abstract class AsyncIterator<T> implements AsyncStream<T> {
     return OperationAsyncIterator.create(
         this,
         sourceCallback ->
-            new MapIteratorCallback<>(
-                new FlattenIteratorCallback<>(sourceCallback), toIteratorMapper));
+            new MapStreamHandler<>(
+                new FlattenStreamHandler<>(sourceCallback), toIteratorMapper));
   }
 
   @Override
   public <R> AsyncIterator<R> map(Function<T, R> mapper) {
     return OperationAsyncIterator.create(
-        this, sourceCallback -> new MapIteratorCallback<>(sourceCallback, mapper));
+        this, sourceCallback -> new MapStreamHandler<>(sourceCallback, mapper));
   }
 
   @Override
   public AsyncIterator<T> filter(Predicate<T> filter) {
     return OperationAsyncIterator.create(
-        this, sourceCallback -> new FilteringIteratorCallback<>(sourceCallback, filter));
+        this, sourceCallback -> new FilteringStreamHandler<>(sourceCallback, filter));
   }
 
   @Override
-  public <A, R> SafeFuture<R> collect(Collector<T, A, R> collector) {
-    return new AsyncIteratorCollector<>(this).collect(collector);
+  public void consume(AsyncStreamHandler<T> consumer) {
+    iterate(consumer);
   }
 
   @Override
   public AsyncStream<T> slice(BaseSlicer<T> slicer) {
     return OperationAsyncIterator.create(
-        this, sourceCallback -> new SliceIteratorCallback<>(sourceCallback, slicer));
+        this, sourceCallback -> new SliceStreamHandler<>(sourceCallback, slicer));
   }
 }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncQueue.java
@@ -1,0 +1,10 @@
+package tech.pegasys.teku.infrastructure.async.stream;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+interface AsyncQueue<T> {
+
+  void put(T item);
+
+  SafeFuture<T> take();
+}

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncQueue.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.infrastructure.async.stream;
 
 import tech.pegasys.teku.infrastructure.async.SafeFuture;

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStream.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStream.java
@@ -19,10 +19,16 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
 /** Similar to {@link java.util.stream.Stream} but may perform async operations */
-public interface AsyncStream<T> extends AsyncStreamTransform<T>, AsyncStreamReduce<T> {
+public interface AsyncStream<T> extends AsyncStreamTransform<T>, AsyncStreamConsume<T> {
 
   static <T> AsyncStream<T> empty() {
     return of();
+  }
+
+  static <T> AsyncStream<T> exceptional(Throwable error) {
+    AsyncStreamPublisher<T> ret = createPublisher(1);
+    ret.onError(error);
+    return ret;
   }
 
   @SafeVarargs
@@ -40,5 +46,9 @@ public interface AsyncStream<T> extends AsyncStreamTransform<T>, AsyncStreamRedu
 
   static <T> AsyncStream<T> create(CompletionStage<T> future) {
     return new FutureAsyncIteratorImpl<>(future);
+  }
+
+  static <T> AsyncStreamPublisher<T> createPublisher(int maxBufferSize) {
+    return new BufferingStreamPublisher<>(maxBufferSize);
   }
 }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamConsume.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamConsume.java
@@ -23,7 +23,13 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
-public interface AsyncStreamReduce<T> extends BaseAsyncStreamReduce<T>, AsyncStreamTransform<T> {
+public interface AsyncStreamConsume<T> extends BaseAsyncStreamConsume<T>, AsyncStreamTransform<T> {
+
+  default <A, R> SafeFuture<R> collect(Collector<T, A, R> collector) {
+    AsyncIteratorCollector<T, A, R> asyncIteratorCollector = new AsyncIteratorCollector<>(collector);
+    consume(asyncIteratorCollector);
+    return asyncIteratorCollector.getPromise();
+  }
 
   default SafeFuture<Optional<T>> findFirst() {
     return this.limit(1)

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamConsume.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamConsume.java
@@ -26,7 +26,8 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 public interface AsyncStreamConsume<T> extends BaseAsyncStreamConsume<T>, AsyncStreamTransform<T> {
 
   default <A, R> SafeFuture<R> collect(Collector<T, A, R> collector) {
-    AsyncIteratorCollector<T, A, R> asyncIteratorCollector = new AsyncIteratorCollector<>(collector);
+    AsyncIteratorCollector<T, A, R> asyncIteratorCollector =
+        new AsyncIteratorCollector<>(collector);
     consume(asyncIteratorCollector);
     return asyncIteratorCollector.getPromise();
   }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamHandler.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamHandler.java
@@ -19,7 +19,7 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
  * Internal {@link AsyncStream} implementation interface which is analogous to {@link
  * java.util.concurrent.Flow.Subscriber} in RX world
  */
-interface AsyncIteratorCallback<T> {
+public interface AsyncStreamHandler<T> {
 
   SafeFuture<Boolean> TRUE_FUTURE = SafeFuture.completedFuture(true);
   SafeFuture<Boolean> FALSE_FUTURE = SafeFuture.completedFuture(false);

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamPublisher.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamPublisher.java
@@ -1,0 +1,3 @@
+package tech.pegasys.teku.infrastructure.async.stream;
+
+public interface AsyncStreamPublisher<T> extends AsyncStreamHandler<T>, AsyncStream<T> {}

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamPublisher.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamPublisher.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
 package tech.pegasys.teku.infrastructure.async.stream;
 
 public interface AsyncStreamPublisher<T> extends AsyncStreamHandler<T>, AsyncStream<T> {}

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/BaseAsyncStreamConsume.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/BaseAsyncStreamConsume.java
@@ -13,14 +13,11 @@
 
 package tech.pegasys.teku.infrastructure.async.stream;
 
-import java.util.stream.Collector;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
-
 /**
  * Contains fundamental terminal (reduce or collect) stream methods All other terminal methods are
  * expressed my means of those methods
  */
-public interface BaseAsyncStreamReduce<T> {
+public interface BaseAsyncStreamConsume<T> {
 
-  <A, R> SafeFuture<R> collect(Collector<T, A, R> collector);
+  void consume(AsyncStreamHandler<T> consumer);
 }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/BufferingStreamPublisher.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/BufferingStreamPublisher.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async.stream;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+class BufferingStreamPublisher<T> extends AsyncIterator<T> implements AsyncStreamPublisher<T> {
+
+  private final AsyncQueue<Event<T>> eventQueue;
+
+  private boolean isDone = false;
+
+  BufferingStreamPublisher(int maxBufferSize) {
+    this.eventQueue = new LimitedAsyncQueue<>(maxBufferSize);
+  }
+
+  sealed interface Event<T> {
+    boolean isTerminal();
+  }
+  record ItemEvent<T>(T item, SafeFuture<Boolean> nextReturn) implements Event<T>{
+    @Override
+    public boolean isTerminal() {
+      return false;
+    }
+  }
+  record CompleteEvent<T>() implements Event<T>{
+    @Override
+    public boolean isTerminal() {
+      return true;
+    }
+  }
+  record ErrorEvent<T>(Throwable error) implements Event<T>{
+    @Override
+    public boolean isTerminal() {
+      return true;
+    }
+  }
+
+  private synchronized void putNext(Event<T> event) {
+    if (isDone) {
+      throw new IllegalStateException("Stream has been done already");
+    }
+    isDone = event.isTerminal();
+    eventQueue.put(event);
+  }
+
+  private SafeFuture<Event<T>> takeNext() {
+    return eventQueue.take();
+  }
+
+  void iterate(AsyncStreamHandler<T> delegate) {
+    SafeFuture.asyncDoWhile(
+        () ->
+          takeNext()
+              .thenApply(
+                  event -> {
+                    switch (event) {
+                      case ItemEvent<T> item -> delegate.onNext(item.item()).propagateTo(item.nextReturn());
+                      case CompleteEvent<T> ignored -> delegate.onComplete();
+                      case ErrorEvent<T> errorEvent -> delegate.onError(errorEvent.error());
+                    }
+                    return event.isTerminal();
+                  })
+        );
+  }
+
+  @Override
+  public SafeFuture<Boolean> onNext(T t) {
+    SafeFuture<Boolean> ret = new SafeFuture<>();
+    try {
+      putNext(new ItemEvent<>(t, ret));
+    } catch (Exception e) {
+      ret.completeExceptionally(e);
+    }
+    return ret;
+  }
+
+  @Override
+  public void onComplete() {
+    putNext(new CompleteEvent<>());
+  }
+
+  @Override
+  public synchronized void onError(Throwable t) {
+    putNext(new ErrorEvent<>(t));
+  }
+}

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/BufferingStreamPublisher.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/BufferingStreamPublisher.java
@@ -28,19 +28,22 @@ class BufferingStreamPublisher<T> extends AsyncIterator<T> implements AsyncStrea
   sealed interface Event<T> {
     boolean isTerminal();
   }
-  record ItemEvent<T>(T item, SafeFuture<Boolean> nextReturn) implements Event<T>{
+
+  record ItemEvent<T>(T item, SafeFuture<Boolean> nextReturn) implements Event<T> {
     @Override
     public boolean isTerminal() {
       return false;
     }
   }
-  record CompleteEvent<T>() implements Event<T>{
+
+  record CompleteEvent<T>() implements Event<T> {
     @Override
     public boolean isTerminal() {
       return true;
     }
   }
-  record ErrorEvent<T>(Throwable error) implements Event<T>{
+
+  record ErrorEvent<T>(Throwable error) implements Event<T> {
     @Override
     public boolean isTerminal() {
       return true;
@@ -64,20 +67,21 @@ class BufferingStreamPublisher<T> extends AsyncIterator<T> implements AsyncStrea
         () ->
             takeNext()
                 .thenCompose(
-                    event -> switch (event) {
-                      case ItemEvent<T> item -> {
-                        delegate.onNext(item.item()).propagateTo(item.nextReturn());
-                        yield item.nextReturn();
-                      }
-                      case CompleteEvent<T> ignored -> {
-                        delegate.onComplete();
-                        yield FALSE_FUTURE;
-                      }
-                      case ErrorEvent<T> errorEvent -> {
-                        delegate.onError(errorEvent.error());
-                        yield FALSE_FUTURE;
-                      }
-                    }));
+                    event ->
+                        switch (event) {
+                          case ItemEvent<T> item -> {
+                            delegate.onNext(item.item()).propagateTo(item.nextReturn());
+                            yield item.nextReturn();
+                          }
+                          case CompleteEvent<T> ignored -> {
+                            delegate.onComplete();
+                            yield FALSE_FUTURE;
+                          }
+                          case ErrorEvent<T> errorEvent -> {
+                            delegate.onError(errorEvent.error());
+                            yield FALSE_FUTURE;
+                          }
+                        }));
   }
 
   @Override

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/FlattenStreamHandler.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/FlattenStreamHandler.java
@@ -15,10 +15,10 @@ package tech.pegasys.teku.infrastructure.async.stream;
 
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
-class FlattenIteratorCallback<TCol extends AsyncIterator<T>, T>
-    extends AbstractDelegatingIteratorCallback<T, TCol> {
+class FlattenStreamHandler<TCol extends AsyncIterator<T>, T>
+    extends AbstractDelegatingStreamHandler<T, TCol> {
 
-  protected FlattenIteratorCallback(AsyncIteratorCallback<T> delegate) {
+  protected FlattenStreamHandler(AsyncStreamHandler<T> delegate) {
     super(delegate);
   }
 
@@ -26,7 +26,7 @@ class FlattenIteratorCallback<TCol extends AsyncIterator<T>, T>
   public SafeFuture<Boolean> onNext(TCol asyncIterator) {
     SafeFuture<Boolean> ret = new SafeFuture<>();
     asyncIterator.iterate(
-        new AsyncIteratorCallback<T>() {
+        new AsyncStreamHandler<T>() {
           @Override
           public SafeFuture<Boolean> onNext(T t) {
             SafeFuture<Boolean> proceedFuture = delegate.onNext(t);

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/LimitedAsyncQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/LimitedAsyncQueue.java
@@ -1,0 +1,48 @@
+package tech.pegasys.teku.infrastructure.async.stream;
+
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+
+class LimitedAsyncQueue<T> implements AsyncQueue<T> {
+
+  private final int maxSize;
+
+  private final Queue<T> items = new LinkedList<>();
+  private final Queue<SafeFuture<T>> takers = new LinkedList<>();
+
+  public LimitedAsyncQueue(int maxSize) {
+    this.maxSize = maxSize;
+  }
+
+  // Adds an item to the queue
+  public synchronized void put(T item) {
+    if (!takers.isEmpty()) {
+      // If there are pending takers, complete one with the item
+      CompletableFuture<T> taker = takers.poll();
+      taker.complete(item);
+    } else {
+      // Otherwise, add the item to the items queue
+      if (items.size() >= maxSize) {
+        throw new IllegalStateException("Buffer size overflow: " + maxSize);
+      }
+      items.offer(item);
+    }
+  }
+
+  // Returns a CompletableFuture that will be completed when an item is available
+  public synchronized SafeFuture<T> take() {
+    if (!items.isEmpty()) {
+      // If items are available, return a completed future
+      T item = items.poll();
+      return SafeFuture.completedFuture(item);
+    } else {
+      // If no items, create a new CompletableFuture and add it to takers
+      SafeFuture<T> future = new SafeFuture<>();
+      takers.offer(future);
+      return future;
+    }
+  }
+}

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/LimitedAsyncQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/LimitedAsyncQueue.java
@@ -1,10 +1,22 @@
-package tech.pegasys.teku.infrastructure.async.stream;
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
+package tech.pegasys.teku.infrastructure.async.stream;
 
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
 class LimitedAsyncQueue<T> implements AsyncQueue<T> {
 

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/LimitedAsyncQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/LimitedAsyncQueue.java
@@ -13,6 +13,7 @@
 
 package tech.pegasys.teku.infrastructure.async.stream;
 
+import java.util.ArrayDeque;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
@@ -22,14 +23,15 @@ class LimitedAsyncQueue<T> implements AsyncQueue<T> {
 
   private final int maxSize;
 
-  private final Queue<T> items = new LinkedList<>();
-  private final Queue<SafeFuture<T>> takers = new LinkedList<>();
+  private final Queue<T> items = new ArrayDeque<>();
+  private final Queue<SafeFuture<T>> takers = new ArrayDeque<>();
 
   public LimitedAsyncQueue(int maxSize) {
     this.maxSize = maxSize;
   }
 
   // Adds an item to the queue
+  @Override
   public synchronized void put(T item) {
     if (!takers.isEmpty()) {
       // If there are pending takers, complete one with the item
@@ -45,6 +47,7 @@ class LimitedAsyncQueue<T> implements AsyncQueue<T> {
   }
 
   // Returns a CompletableFuture that will be completed when an item is available
+  @Override
   public synchronized SafeFuture<T> take() {
     if (!items.isEmpty()) {
       // If items are available, return a completed future

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/LimitedAsyncQueue.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/LimitedAsyncQueue.java
@@ -14,7 +14,6 @@
 package tech.pegasys.teku.infrastructure.async.stream;
 
 import java.util.ArrayDeque;
-import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/MapStreamHandler.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/MapStreamHandler.java
@@ -16,11 +16,11 @@ package tech.pegasys.teku.infrastructure.async.stream;
 import java.util.function.Function;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
-class MapIteratorCallback<T, S> extends AbstractDelegatingIteratorCallback<T, S> {
+class MapStreamHandler<T, S> extends AbstractDelegatingStreamHandler<T, S> {
 
   private final Function<S, T> mapper;
 
-  protected MapIteratorCallback(AsyncIteratorCallback<T> delegate, Function<S, T> mapper) {
+  protected MapStreamHandler(AsyncStreamHandler<T> delegate, Function<S, T> mapper) {
     super(delegate);
     this.mapper = mapper;
   }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/OperationAsyncIterator.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/OperationAsyncIterator.java
@@ -23,8 +23,7 @@ abstract class OperationAsyncIterator<S, T> extends AsyncIterator<T> {
       Function<AsyncStreamHandler<T>, AsyncStreamHandler<S>> callbackMapper) {
     return new OperationAsyncIterator<>(srcIterator) {
       @Override
-      protected AsyncStreamHandler<S> createDelegateCallback(
-          AsyncStreamHandler<T> sourceCallback) {
+      protected AsyncStreamHandler<S> createDelegateCallback(AsyncStreamHandler<T> sourceCallback) {
         return callbackMapper.apply(sourceCallback);
       }
     };

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/OperationAsyncIterator.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/OperationAsyncIterator.java
@@ -20,11 +20,11 @@ abstract class OperationAsyncIterator<S, T> extends AsyncIterator<T> {
 
   public static <S, T> AsyncIterator<T> create(
       AsyncIterator<S> srcIterator,
-      Function<AsyncIteratorCallback<T>, AsyncIteratorCallback<S>> callbackMapper) {
+      Function<AsyncStreamHandler<T>, AsyncStreamHandler<S>> callbackMapper) {
     return new OperationAsyncIterator<>(srcIterator) {
       @Override
-      protected AsyncIteratorCallback<S> createDelegateCallback(
-          AsyncIteratorCallback<T> sourceCallback) {
+      protected AsyncStreamHandler<S> createDelegateCallback(
+          AsyncStreamHandler<T> sourceCallback) {
         return callbackMapper.apply(sourceCallback);
       }
     };
@@ -34,11 +34,11 @@ abstract class OperationAsyncIterator<S, T> extends AsyncIterator<T> {
     this.delegateIterator = delegateIterator;
   }
 
-  protected abstract AsyncIteratorCallback<S> createDelegateCallback(
-      AsyncIteratorCallback<T> sourceCallback);
+  protected abstract AsyncStreamHandler<S> createDelegateCallback(
+      AsyncStreamHandler<T> sourceCallback);
 
   @Override
-  public void iterate(AsyncIteratorCallback<T> callback) {
+  public void iterate(AsyncStreamHandler<T> callback) {
     delegateIterator.iterate(createDelegateCallback(callback));
   }
 }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/SliceStreamHandler.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/SliceStreamHandler.java
@@ -30,8 +30,15 @@ class SliceStreamHandler<T> extends AbstractDelegatingStreamHandler<T, T> {
     BaseAsyncStreamTransform.SliceResult sliceResult = slicer.slice(t);
     return switch (sliceResult) {
       case CONTINUE -> delegate.onNext(t);
-      case SKIP_AND_STOP -> FALSE_FUTURE;
-      case INCLUDE_AND_STOP -> delegate.onNext(t).thenApply(__ -> false);
+      case SKIP_AND_STOP -> {
+        delegate.onComplete();
+        yield FALSE_FUTURE;
+      }
+      case INCLUDE_AND_STOP -> {
+        SafeFuture<Boolean> ret = delegate.onNext(t).thenApply(__ -> false);
+        delegate.onComplete();
+        yield ret;
+      }
     };
   }
 }

--- a/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/SyncToAsyncIteratorImpl.java
+++ b/infrastructure/async/src/main/java/tech/pegasys/teku/infrastructure/async/stream/SyncToAsyncIteratorImpl.java
@@ -19,14 +19,14 @@ import tech.pegasys.teku.infrastructure.async.SafeFuture;
 class SyncToAsyncIteratorImpl<T> extends AsyncIterator<T> {
 
   private final Iterator<T> iterator;
-  private AsyncIteratorCallback<T> callback;
+  private AsyncStreamHandler<T> callback;
 
   SyncToAsyncIteratorImpl(Iterator<T> iterator) {
     this.iterator = iterator;
   }
 
   @Override
-  public void iterate(AsyncIteratorCallback<T> callback) {
+  public void iterate(AsyncStreamHandler<T> callback) {
     synchronized (this) {
       if (this.callback != null) {
         throw new IllegalStateException("This one-shot iterator has been used already");

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamPublisherTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamPublisherTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Consensys Software Inc., 2024
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package tech.pegasys.teku.infrastructure.async.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
+
+public class AsyncStreamPublisherTest {
+
+  AsyncStreamPublisher<Integer> publisher = AsyncStream.createPublisher(Integer.MAX_VALUE);
+
+  @Test
+  void sanityTest() {
+    ArrayList<Integer> collector = new ArrayList<>();
+
+    SafeFuture<List<Integer>> listPromise =
+        publisher
+            .flatMap(
+                i -> AsyncStream.create(IntStream.range(i * 10, i * 10 + 5).boxed().iterator()))
+            .filter(i -> i % 2 == 0)
+            .map(i -> i * 10)
+            .limit(10)
+            .collect(collector);
+
+    assertThat(collector).isEmpty();
+
+    publisher.onNext(0);
+    assertThat(collector).containsExactly(0, 20, 40);
+
+    publisher.onNext(1);
+    assertThat(collector).containsExactly(0, 20, 40, 100, 120, 140);
+
+    publisher.onNext(2);
+    assertThat(collector).containsExactly(0, 20, 40, 100, 120, 140, 200, 220, 240);
+    assertThat(listPromise).isNotDone();
+
+    publisher.onNext(3);
+    // limit(10) kicks in
+    assertThat(collector).containsExactly(0, 20, 40, 100, 120, 140, 200, 220, 240, 300);
+    assertThat(listPromise)
+        .isCompletedWithValue(List.of(0, 20, 40, 100, 120, 140, 200, 220, 240, 300));
+  }
+
+  @Test
+  void completeShouldCompleteStream() {
+    SafeFuture<List<Integer>> listPromise =
+        publisher
+            .flatMap(
+                i -> AsyncStream.create(IntStream.range(i * 10, i * 10 + 5).boxed().iterator()))
+            .filter(i -> i % 2 == 0)
+            .map(i -> i * 10)
+            .toList();
+
+    publisher.onNext(0);
+    publisher.onComplete();
+    assertThat(listPromise).isCompletedWithValue(List.of(0, 20, 40));
+  }
+
+  @Test
+  void errorShouldCompleteStream() {
+    SafeFuture<List<Integer>> listPromise =
+        publisher
+            .flatMap(
+                i -> AsyncStream.create(IntStream.range(i * 10, i * 10 + 5).boxed().iterator()))
+            .filter(i -> i % 2 == 0)
+            .map(i -> i * 10)
+            .toList();
+
+    publisher.onNext(0);
+    publisher.onError(new RuntimeException("test"));
+    assertThat(listPromise).isCompletedExceptionally();
+  }
+}

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamPublisherTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamPublisherTest.java
@@ -21,6 +21,7 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 
+@SuppressWarnings("FutureReturnValueIgnored")
 public class AsyncStreamPublisherTest {
 
   AsyncStreamPublisher<Integer> publisher = AsyncStream.createPublisher(Integer.MAX_VALUE);
@@ -40,17 +41,29 @@ public class AsyncStreamPublisherTest {
 
     assertThat(collector).isEmpty();
 
-    publisher.onNext(0);
+    {
+      SafeFuture<Boolean> f = publisher.onNext(0);
+      assertThat(f).isCompletedWithValue(true);
+    }
     assertThat(collector).containsExactly(0, 20, 40);
 
-    publisher.onNext(1);
+    {
+      SafeFuture<Boolean> f = publisher.onNext(1);
+      assertThat(f).isCompletedWithValue(true);
+    }
     assertThat(collector).containsExactly(0, 20, 40, 100, 120, 140);
 
-    publisher.onNext(2);
+    {
+      SafeFuture<Boolean> f = publisher.onNext(2);
+      assertThat(f).isCompletedWithValue(true);
+    }
     assertThat(collector).containsExactly(0, 20, 40, 100, 120, 140, 200, 220, 240);
     assertThat(listPromise).isNotDone();
 
-    publisher.onNext(3);
+    {
+      SafeFuture<Boolean> f = publisher.onNext(3);
+      assertThat(f).isCompletedWithValue(false);
+    }
     // limit(10) kicks in
     assertThat(collector).containsExactly(0, 20, 40, 100, 120, 140, 200, 220, 240, 300);
     assertThat(listPromise)

--- a/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamPublisherTest.java
+++ b/infrastructure/async/src/test/java/tech/pegasys/teku/infrastructure/async/stream/AsyncStreamPublisherTest.java
@@ -17,9 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DataColumnPeerManagerImpl.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DataColumnPeerManagerImpl.java
@@ -13,10 +13,12 @@
 
 package tech.pegasys.teku.networking.eth2.peers;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.tuweni.units.bigints.UInt256;
+import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStreamPublisher;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DataColumnPeerManagerImpl.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DataColumnPeerManagerImpl.java
@@ -13,22 +13,24 @@
 
 package tech.pegasys.teku.networking.eth2.peers;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.tuweni.units.bigints.UInt256;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
+import tech.pegasys.teku.infrastructure.async.stream.AsyncStreamPublisher;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
+import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.networking.p2p.peer.PeerConnectedSubscriber;
 import tech.pegasys.teku.spec.datastructures.blobs.versions.eip7594.DataColumnSidecar;
 import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIdentifier;
-import tech.pegasys.teku.statetransition.datacolumns.retriever.BatchDataColumnReqResp;
+import tech.pegasys.teku.statetransition.datacolumns.retriever.BatchDataColumnsByRangeReqResp;
+import tech.pegasys.teku.statetransition.datacolumns.retriever.BatchDataColumnsByRootReqResp;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnPeerManager;
 import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnReqResp;
 
 public class DataColumnPeerManagerImpl
-    implements DataColumnPeerManager, PeerConnectedSubscriber<Eth2Peer>, BatchDataColumnReqResp {
+    implements DataColumnPeerManager, PeerConnectedSubscriber<Eth2Peer>, BatchDataColumnsByRootReqResp, BatchDataColumnsByRangeReqResp {
 
   private final Subscribers<PeerListener> listeners = Subscribers.create(true);
   private Map<UInt256, Eth2Peer> connectedPeers = new ConcurrentHashMap<>();
@@ -62,22 +64,34 @@ public class DataColumnPeerManagerImpl
   }
 
   @Override
-  public SafeFuture<List<DataColumnSidecar>> requestDataColumnSidecar(
+  public AsyncStream<DataColumnSidecar> requestDataColumnSidecarsByRoot(
       UInt256 nodeId, List<DataColumnIdentifier> columnIdentifiers) {
     Eth2Peer eth2Peer = connectedPeers.get(nodeId);
+    AsyncStreamPublisher<DataColumnSidecar> ret = AsyncStream.createPublisher(Integer.MAX_VALUE);
     if (eth2Peer == null) {
-      return SafeFuture.failedFuture(new DataColumnReqResp.DasPeerDisconnectedException());
+      ret.onError(new DataColumnReqResp.DasPeerDisconnectedException());
     } else {
-      List<DataColumnSidecar> responseCollector = new ArrayList<>();
-      return eth2Peer
-          .requestDataColumnSidecarsByRoot(
-              columnIdentifiers,
-              sidecar -> {
-                responseCollector.add(sidecar);
-                return SafeFuture.COMPLETE;
-              })
-          .thenApply(__ -> responseCollector);
+      eth2Peer
+          .requestDataColumnSidecarsByRoot(columnIdentifiers, ret::onNext)
+          .finish(__ -> ret.onComplete(), ret::onError);
     }
+    return ret;
+  }
+
+  @Override
+  public AsyncStream<DataColumnSidecar> requestDataColumnSidecarsByRange(
+      UInt256 nodeId, UInt64 startSlot, int slotCount, List<UInt64> columnIndexes) {
+    Eth2Peer eth2Peer = connectedPeers.get(nodeId);
+    AsyncStreamPublisher<DataColumnSidecar> ret = AsyncStream.createPublisher(Integer.MAX_VALUE);
+    if (eth2Peer == null) {
+      ret.onError(new DataColumnReqResp.DasPeerDisconnectedException());
+    } else {
+      eth2Peer
+          .requestDataColumnSidecarsByRange(
+              startSlot, UInt64.valueOf(slotCount), columnIndexes, ret::onNext)
+          .finish(__ -> ret.onComplete(), ret::onError);
+    }
+    return ret;
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DataColumnPeerManagerImpl.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/DataColumnPeerManagerImpl.java
@@ -13,12 +13,10 @@
 
 package tech.pegasys.teku.networking.eth2.peers;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.tuweni.units.bigints.UInt256;
-import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStream;
 import tech.pegasys.teku.infrastructure.async.stream.AsyncStreamPublisher;
 import tech.pegasys.teku.infrastructure.subscribers.Subscribers;
@@ -32,7 +30,10 @@ import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnPeerMan
 import tech.pegasys.teku.statetransition.datacolumns.retriever.DataColumnReqResp;
 
 public class DataColumnPeerManagerImpl
-    implements DataColumnPeerManager, PeerConnectedSubscriber<Eth2Peer>, BatchDataColumnsByRootReqResp, BatchDataColumnsByRangeReqResp {
+    implements DataColumnPeerManager,
+        PeerConnectedSubscriber<Eth2Peer>,
+        BatchDataColumnsByRootReqResp,
+        BatchDataColumnsByRangeReqResp {
 
   private final Subscribers<PeerListener> listeners = Subscribers.create(true);
   private Map<UInt256, Eth2Peer> connectedPeers = new ConcurrentHashMap<>();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

When requesting large batch of data columns it could take time to return all of them. 
`AsyncStream` is yielding them one-by-one while they arrive from network which both reduces latency by 50% on average and spreads the responses processing load through a period. 

- `AsyncStream:`
  - Refactor and rename some `AsyncStream` classes
  - Add `AsyncStreamPublisher` and its implementation 
  - Add a generic `AsyncSteram.consume()`method
  - Add a publisher test
- Add columns by range interface `BatchDataColumnsByRangeReqResp`
- Convert `BatchDataColumnsByRootReqResp` to return `AsyncStream` instead of `SafeFuture<List>`
- Implement the above in `DataColumnPeerManagerImpl`
- Adopt `AsyncStream` usage in `DataColumnReqRespBatchingImpl`