### PR TITLE
Fix SimpleSidecarRetriever cache

### DIFF
--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
@@ -73,10 +73,10 @@ public class SimpleSidecarRetrieverTest {
           stubAsyncRunner,
           retrieverRound);
 
-  UInt64 columnId = UInt64.valueOf(1);
+  UInt64 columnIndex = UInt64.valueOf(1);
 
-  Iterator<UInt256> custodyNodeIds = craftNodeIdsCustodyOf(columnId).iterator();
-  Iterator<UInt256> nonCustodyNodeIds = craftNodeIdsNotCustodyOf(columnId).iterator();
+  Iterator<UInt256> custodyNodeIds = craftNodeIdsCustodyOf(columnIndex).iterator();
+  Iterator<UInt256> nonCustodyNodeIds = craftNodeIdsNotCustodyOf(columnIndex).iterator();
 
   private final DataStructureUtil dataStructureUtil = new DataStructureUtil(0, spec);
   final CanonicalBlockResolverStub blockResolver = new CanonicalBlockResolverStub(spec);
@@ -131,9 +131,9 @@ public class SimpleSidecarRetrieverTest {
     BeaconBlock block = blockResolver.addBlock(10, 1);
     List<DataColumnSidecar> sidecars =
         miscHelpers.constructDataColumnSidecars(createSigned(block), blobs, kzg);
-    DataColumnSidecar sidecar0 = sidecars.get(columnId.intValue());
+    DataColumnSidecar sidecar0 = sidecars.get(columnIndex.intValue());
 
-    DataColumnSlotAndIdentifier id0 = createId(block, columnId.intValue());
+    DataColumnSlotAndIdentifier id0 = createId(block, columnIndex.intValue());
 
     testPeerManager.connectPeer(custodyPeerMissingData);
     testPeerManager.connectPeer(nonCustodyPeer);
@@ -182,7 +182,7 @@ public class SimpleSidecarRetrieverTest {
     allPeers.forEach(testPeerManager::connectPeer);
 
     DataColumnSlotAndIdentifier id0 =
-        new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, columnId);
+        new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, columnIndex);
     SafeFuture<DataColumnSidecar> resp0 = simpleSidecarRetriever.retrieve(id0);
 
     advanceTimeGradually(retrieverRound);
@@ -217,7 +217,7 @@ public class SimpleSidecarRetrieverTest {
     testPeerManager.connectPeer(custodyPeer);
 
     DataColumnSlotAndIdentifier id0 =
-        new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, columnId);
+        new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, columnIndex);
     SafeFuture<DataColumnSidecar> resp0_0 = simpleSidecarRetriever.retrieve(id0);
 
     advanceTimeGradually(retrieverRound);
@@ -243,7 +243,7 @@ public class SimpleSidecarRetrieverTest {
                     new TestPeer(stubAsyncRunner, nodeId, Duration.ofMillis(100))
                         .currentRequestLimit(1000))
             .limit(128)
-            .peek(node -> custodyCountSupplier.addCustomCount(node.getNodeId(), columnCount))
+            .peek(node -> custodyCountSupplier.setCustomCount(node.getNodeId(), columnCount))
             .peek(testPeerManager::connectPeer)
             .toList();
 
@@ -262,5 +262,37 @@ public class SimpleSidecarRetrieverTest {
         columnIds.stream().map(simpleSidecarRetriever::retrieve).toList();
 
     Assertions.assertTimeout(Duration.ofSeconds(10), () -> advanceTimeGradually(retrieverRound));
+  }
+
+  @Test
+  void shouldTrackCustodyCountChangesForPeers() {
+    Duration responseLatency = Duration.ofDays(1); // complete responses manually
+    TestPeer peer =
+        new TestPeer(stubAsyncRunner, custodyNodeIds.next(), responseLatency)
+            .currentRequestLimit(1000);
+    testPeerManager.connectPeer(peer);
+
+    List<DataColumnSlotAndIdentifier> colIds = IntStream.range(0, columnCount)
+        .mapToObj(UInt64::valueOf)
+        .map(colIdx -> new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, colIdx))
+        .toList();
+
+    colIds.forEach(simpleSidecarRetriever::retrieve);
+
+    int peerCustodyCount = custodyCountSupplier.getCustodyCountForPeer(peer.getNodeId());
+
+    advanceTimeGradually(retrieverRound);
+    assertThat(peer.getRequests()).hasSize(peerCustodyCount);
+
+    int newPeerCustodyCount = peerCustodyCount + 1;
+    custodyCountSupplier.setCustomCount(peer.getNodeId(), newPeerCustodyCount);
+
+    advanceTimeGradually(retrieverRound);
+    assertThat(peer.getRequests()).hasSize(newPeerCustodyCount);
+
+    custodyCountSupplier.setCustomCount(peer.getNodeId(), columnCount);
+
+    advanceTimeGradually(retrieverRound);
+    assertThat(peer.getRequests()).hasSize(columnCount);
   }
 }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
@@ -265,6 +265,7 @@ public class SimpleSidecarRetrieverTest {
   }
 
   @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
   void shouldTrackCustodyCountChangesForPeers() {
     Duration responseLatency = Duration.ofDays(1); // complete responses manually
     TestPeer peer =

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetrieverTest.java
@@ -272,10 +272,11 @@ public class SimpleSidecarRetrieverTest {
             .currentRequestLimit(1000);
     testPeerManager.connectPeer(peer);
 
-    List<DataColumnSlotAndIdentifier> colIds = IntStream.range(0, columnCount)
-        .mapToObj(UInt64::valueOf)
-        .map(colIdx -> new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, colIdx))
-        .toList();
+    List<DataColumnSlotAndIdentifier> colIds =
+        IntStream.range(0, columnCount)
+            .mapToObj(UInt64::valueOf)
+            .map(colIdx -> new DataColumnSlotAndIdentifier(UInt64.ONE, Bytes32.ZERO, colIdx))
+            .toList();
 
     colIds.forEach(simpleSidecarRetriever::retrieve);
 

--- a/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DasPeerCustodyCountSupplierStub.java
+++ b/ethereum/statetransition/src/testFixtures/java/tech/pegasys/teku/statetransition/datacolumns/retriever/DasPeerCustodyCountSupplierStub.java
@@ -30,7 +30,7 @@ public class DasPeerCustodyCountSupplierStub implements DasPeerCustodyCountSuppl
     return customCounts.getOrDefault(nodeId, defaultCount);
   }
 
-  public void addCustomCount(UInt256 nodeId, int count) {
+  public void setCustomCount(UInt256 nodeId, int count) {
     customCounts.put(nodeId, count);
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

A remote peer custody count is updated asynchronously, so we should account this value in the cache and be aware of its updates   

