### PR TITLE
Fix missing Gossip subnet subscription on startup

### DIFF
--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/ActiveEth2P2PNetwork.java
@@ -182,6 +182,8 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
 
   @Override
   public void onSyncStateChanged(final boolean isInSync, final boolean isOptimistic) {
+    gossipForkManager.onOptimisticHeadChanged(isOptimistic);
+
     if (state.get() != State.RUNNING) {
       return;
     }
@@ -190,7 +192,6 @@ public class ActiveEth2P2PNetwork extends DelegatingP2PNetwork<Eth2Peer> impleme
     } else {
       stopGossip();
     }
-    gossipForkManager.onOptimisticHeadChanged(isOptimistic);
   }
 
   @VisibleForTesting

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
@@ -302,7 +302,7 @@ public class GossipForkManager {
     return activeSubscriptions.contains(subscriptions);
   }
 
-  private synchronized void startSubscriptions(final GossipForkSubscriptions subscription) {
+  private void startSubscriptions(final GossipForkSubscriptions subscription) {
     if (activeSubscriptions.add(subscription)) {
       subscription.startGossip(genesisValidatorsRoot, isHeadOptimistic);
       currentAttestationSubnets.forEach(subscription::subscribeToAttestationSubnetId);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManager.java
@@ -29,6 +29,7 @@ import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes32;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.spec.Spec;
 import tech.pegasys.teku.spec.datastructures.attestation.ValidatableAttestation;
@@ -56,7 +57,7 @@ public class GossipForkManager {
   private static final Logger LOG = LogManager.getLogger();
   private static final int EPOCHS_PRIOR_TO_FORK_TO_ACTIVATE = 2;
   private final Spec spec;
-  private final RecentChainData recentChainData;
+  private final Bytes32 genesisValidatorsRoot;
   private final NavigableMap<UInt64, GossipForkSubscriptions> forksByActivationEpoch;
   private final Set<GossipForkSubscriptions> activeSubscriptions = new HashSet<>();
   private final IntSet currentAttestationSubnets = new IntOpenHashSet();
@@ -64,13 +65,16 @@ public class GossipForkManager {
   private final IntSet currentDataColumnSidecarSubnets = new IntOpenHashSet();
 
   private Optional<UInt64> currentEpoch = Optional.empty();
+  private boolean isHeadOptimistic;
 
   private GossipForkManager(
       final Spec spec,
-      final RecentChainData recentChainData,
+      final Bytes32 genesisValidatorsRoot,
+      final boolean isHeadOptimistic,
       final NavigableMap<UInt64, GossipForkSubscriptions> forksByActivationEpoch) {
     this.spec = spec;
-    this.recentChainData = recentChainData;
+    this.genesisValidatorsRoot = genesisValidatorsRoot;
+    this.isHeadOptimistic = isHeadOptimistic;
     this.forksByActivationEpoch = forksByActivationEpoch;
   }
 
@@ -142,14 +146,12 @@ public class GossipForkManager {
   }
 
   public synchronized void onOptimisticHeadChanged(final boolean isHeadOptimistic) {
+    this.isHeadOptimistic = isHeadOptimistic;
     if (isHeadOptimistic) {
       activeSubscriptions.forEach(GossipForkSubscriptions::stopGossipForOptimisticSync);
     } else {
       activeSubscriptions.forEach(
-          subscriptions ->
-              subscriptions.startGossip(
-                  recentChainData.getGenesisData().orElseThrow().getGenesisValidatorsRoot(),
-                  false));
+          subscriptions -> subscriptions.startGossip(genesisValidatorsRoot, false));
     }
   }
 
@@ -300,11 +302,9 @@ public class GossipForkManager {
     return activeSubscriptions.contains(subscriptions);
   }
 
-  private void startSubscriptions(final GossipForkSubscriptions subscription) {
+  private synchronized void startSubscriptions(final GossipForkSubscriptions subscription) {
     if (activeSubscriptions.add(subscription)) {
-      subscription.startGossip(
-          recentChainData.getGenesisData().orElseThrow().getGenesisValidatorsRoot(),
-          recentChainData.isChainHeadOptimistic());
+      subscription.startGossip(genesisValidatorsRoot, isHeadOptimistic);
       currentAttestationSubnets.forEach(subscription::subscribeToAttestationSubnetId);
       currentSyncCommitteeSubnets.forEach(subscription::subscribeToSyncCommitteeSubnet);
       currentDataColumnSidecarSubnets.forEach(subscription::subscribeToDataColumnSidecarSubnet);
@@ -356,7 +356,11 @@ public class GossipForkManager {
       checkNotNull(spec, "Must supply spec");
       checkNotNull(recentChainData, "Must supply recentChainData");
       checkState(!forksByActivationEpoch.isEmpty(), "Must specify at least one fork");
-      return new GossipForkManager(spec, recentChainData, forksByActivationEpoch);
+      return new GossipForkManager(
+          spec,
+          recentChainData.getGenesisData().orElseThrow().getGenesisValidatorsRoot(),
+          recentChainData.isChainHeadOptimistic(),
+          forksByActivationEpoch);
     }
   }
 }

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManagerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/gossip/forks/GossipForkManagerTest.java
@@ -504,6 +504,19 @@ class GossipForkManagerTest {
     verify(subscriptions).startGossip(GENESIS_VALIDATORS_ROOT, true);
   }
 
+  @Test
+  void shouldStartSubscriptionsInNonOptimisticSyncModeWhenSyncStateChangedBeforeStart() {
+    when(recentChainData.isChainHeadOptimistic()).thenReturn(true);
+
+    final GossipForkSubscriptions subscriptions = forkAtEpoch(0);
+    final GossipForkManager manager = managerForForks(subscriptions);
+
+    manager.onOptimisticHeadChanged(false);
+    manager.configureGossipForEpoch(UInt64.ZERO);
+
+    verify(subscriptions).startGossip(GENESIS_VALIDATORS_ROOT, false);
+  }
+
   private GossipForkSubscriptions forkAtEpoch(final long epoch) {
     final GossipForkSubscriptions subscriptions =
         mock(GossipForkSubscriptions.class, "subscriptionsForEpoch" + epoch);


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

`GossipForkManager` has two different sources of `isHeadOptimistic`flag:  
- `RecentChainData.isChainHeadOptimistic()` when starting up
- `onOptimisticHeadChanged()` to update the flag 

There are possible cases (e.g. #166) when the value differs in those two sources. Thus subnet subscriptions (which are to be activated when `isHeadOptimistic` becomes `false`) may not be activated.

This PR initializes the flag with `RecentChainData.isChainHeadOptimistic()` value and then relies on `onOptimisticHeadChanged()` notifications only 

## Fixed Issue(s)

Fix #166