### PR TITLE
Fix DasLongPollCustody.hasCustodyDataColumnSidecar(), add tests

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustody.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustody.java
@@ -80,7 +80,7 @@ public class DasLongPollCustody implements UpdatableDataColumnSidecarCustody, Sl
     SafeFuture<Optional<Boolean>> existingFuture =
         delegate
             .hasCustodyDataColumnSidecar(columnId)
-            .thenApply(doesExist -> doesExist ? Optional.empty() : Optional.of(true));
+            .thenApply(doesExist -> doesExist ? Optional.of(true) : Optional.empty());
     return anyNonEmpty(pendingFuture, existingFuture)
         .thenApply(maybeResult -> maybeResult.orElse(false));
   }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description

There was a stupid bug which ruined sampling. 
