### PR TITLE
Improve DataColumnIdentifiers cache

### DIFF
--- a/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecar.java
+++ b/ethereum/spec/src/main/java/tech/pegasys/teku/spec/datastructures/blobs/versions/fulu/DataColumnSidecar.java
@@ -29,6 +29,7 @@ import tech.pegasys.teku.spec.datastructures.blocks.SignedBeaconBlockHeader;
 import tech.pegasys.teku.spec.datastructures.blocks.SlotAndBlockRoot;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGCommitment;
 import tech.pegasys.teku.spec.datastructures.type.SszKZGProof;
+import tech.pegasys.teku.spec.datastructures.util.DataColumnSlotAndIdentifier;
 
 public class DataColumnSidecar
     extends Container6<
@@ -129,6 +130,10 @@ public class DataColumnSidecar
 
   public SlotAndBlockRoot getSlotAndBlockRoot() {
     return new SlotAndBlockRoot(getSlot(), getBlockRoot());
+  }
+
+  public DataColumnSlotAndIdentifier getDataColumnSlotAndIdentifier() {
+    return new DataColumnSlotAndIdentifier(getSlot(), getBlockRoot(), getIndex());
   }
 
   public String toLogString() {

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/datacolumns/DasLongPollCustodyTest.java
@@ -143,7 +143,7 @@ public class DasLongPollCustodyTest {
     delayedDb.setDelay(ofMillis(5));
     custody.onNewValidatedDataColumnSidecar(sidecar10_0);
 
-    advanceTimeGradually(ofMillis(10));
+    advanceTimeGradually(ofMillis(15));
     assertThat(fRet0).isCompletedWithValue(Optional.ofNullable(sidecar10_0));
     assertThat(fHas0).isCompletedWithValue(true);
   }


### PR DESCRIPTION
When recovering `DataColumnSidecars` from EL our nodes usually end up saving sidecars 2 times each, one when received from gossip and other from recovery. Moreover the order could be different at any slot. 
This PR addresses this issue