### PR TITLE
Fix: Teku was requesting BlobSidecars in FULU in some cases

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/util/BlockBlobSidecarsTrackersPoolImpl.java
@@ -795,6 +795,11 @@ public class BlockBlobSidecarsTrackersPoolImpl extends AbstractIgnoringFutureHis
     if (blockBlobSidecarsTracker == null || blockBlobSidecarsTracker.isComplete()) {
       return;
     }
+    if (spec.atSlot(slotAndBlockRoot.getSlot())
+        .getMilestone()
+        .isGreaterThanOrEqualTo(SpecMilestone.FULU)) {
+      return;
+    }
 
     if (blockBlobSidecarsTracker.getBlock().isEmpty()) {
 


### PR DESCRIPTION
Looks like Teku was requesting BlobSidecars in some cases. My guess is, it was in case of failing to get Blobs from EL, for example due to timeout. This issue is fixed. 