### PR TITLE
Add peerDAS inclusion proof verification time metric

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
@@ -24,6 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -52,6 +53,19 @@ import tech.pegasys.teku.spec.logic.versions.fulu.helpers.MiscHelpersFulu;
  */
 public class DataColumnSidecarGossipValidator {
   private static final Logger LOG = LogManager.getLogger();
+  public static final BiFunction<MetricsSystem, TimeProvider, MetricsHistogram>
+      DATA_COLUMN_SIDECAR_INCLUSION_PROOF_VERIFICATION_HISTOGRAM =
+          (metricsSystem, timeProvider) ->
+              new MetricsHistogram(
+                  metricsSystem,
+                  timeProvider,
+                  TekuMetricCategory.BEACON,
+                  "data_column_sidecar_inclusion_proof_verification_seconds",
+                  "Time taken to verify data column sidecar inclusion proof",
+                  new double[] {
+                    0.001, 0.002, 0.003, 0.004, 0.005, 0.01, 0.015, 0.02, 0.025, 0.03, 0.04, 0.05,
+                    0.1, 0.5, 1.0
+                  });
 
   private final Spec spec;
   private final Set<SlotProposerIndexAndColumnIndex> receivedValidDataColumnSidecarInfoSet;
@@ -127,16 +141,9 @@ public class DataColumnSidecarGossipValidator {
             "data_column_sidecar_processing_successes_total",
             "Total number of data column sidecars verified for gossip");
     this.dataColumnSidecarInclusionProofVerificationTimeSeconds =
-        new MetricsHistogram(
-            metricsSystem,
-            timeProvider,
-            TekuMetricCategory.BEACON,
-            "data_column_sidecar_inclusion_proof_verification_seconds",
-            "Time taken to verify data column sidecar inclusion proof",
-            new double[] {
-              0.001, 0.002, 0.003, 0.004, 0.005, 0.01, 0.015, 0.02, 0.025, 0.03, 0.04, 0.05, 0.1,
-              0.5, 1.0
-            });
+        DATA_COLUMN_SIDECAR_INCLUSION_PROOF_VERIFICATION_HISTOGRAM.apply(
+            metricsSystem, timeProvider);
+
     this.validInclusionProofInfoSet = validInclusionProofInfoSet;
     this.validSignedBlockHeaders = validSignedBlockHeaders;
   }

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
@@ -369,11 +369,8 @@ public class DataColumnSidecarGossipValidator {
         dataColumnSidecarInclusionProofVerificationTimeSeconds.startTimer()) {
       return miscHelpersFulu.verifyDataColumnSidecarInclusionProof(dataColumnSidecar);
     } catch (final Throwable t) {
-      LOG.error(
-          "Failed to verify inclusion proof for  data column sidecar {}",
-          dataColumnSidecar.toLogString());
+      return false;
     }
-    return false;
   }
 
   private boolean verifyBlockHeaderSignature(

--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidator.java
@@ -370,9 +370,8 @@ public class DataColumnSidecarGossipValidator {
       return miscHelpersFulu.verifyDataColumnSidecarInclusionProof(dataColumnSidecar);
     } catch (final Throwable t) {
       LOG.error(
-          "Failed to reconstruct data column sidecars {}",
-          dataColumnSidecar.getSszKZGCommitments().hashTreeRoot(),
-          t);
+          "Failed to verify inclusion proof for  data column sidecar {}",
+          dataColumnSidecar.toLogString());
     }
     return false;
   }

--- a/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorTest.java
+++ b/ethereum/statetransition/src/test/java/tech/pegasys/teku/statetransition/validation/DataColumnSidecarGossipValidatorTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.TestTemplate;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.async.SafeFutureAssert;
 import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.spec.Spec;
@@ -54,6 +55,7 @@ public class DataColumnSidecarGossipValidatorTest {
   private final MiscHelpersFulu miscHelpersFulu = mock(MiscHelpersFulu.class);
   private final KZG kzg = mock(KZG.class);
   private final MetricsSystem metricsSystemStub = new StubMetricsSystem();
+  private final StubTimeProvider stubTimeProvider = StubTimeProvider.withTimeInMillis(0);
   private DataStructureUtil dataStructureUtil;
   private DataColumnSidecarGossipValidator validator;
 
@@ -79,7 +81,8 @@ public class DataColumnSidecarGossipValidatorTest {
             gossipValidationHelper,
             miscHelpersFulu,
             kzg,
-            metricsSystemStub);
+            metricsSystemStub,
+            stubTimeProvider);
 
     parentSlot = UInt64.valueOf(1);
 
@@ -153,7 +156,8 @@ public class DataColumnSidecarGossipValidatorTest {
             gossipValidationHelper,
             miscHelpersFulu,
             kzg,
-            metricsSystemStub);
+            metricsSystemStub,
+            stubTimeProvider);
 
     SafeFutureAssert.assertThatSafeFuture(validator.validate(dataColumnSidecar))
         .isCompletedWithValueMatching(InternalValidationResult::isReject);
@@ -381,7 +385,8 @@ public class DataColumnSidecarGossipValidatorTest {
             gossipValidationHelper,
             miscHelpersFulu,
             kzg,
-            metricsSystemStub);
+            metricsSystemStub,
+            stubTimeProvider);
     // Accept everything
     when(gossipValidationHelper.isSlotFinalized(any())).thenReturn(false);
     when(gossipValidationHelper.isSlotFromFuture(any())).thenReturn(false);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2Peer.java
@@ -17,9 +17,11 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.units.bigints.UInt256;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.ssz.SszData;
 import tech.pegasys.teku.infrastructure.ssz.collections.SszBitvector;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.rpc.beaconchain.BeaconChainMethods;
@@ -53,7 +55,9 @@ public interface Eth2Peer extends Peer, SyncSource {
       final RateTracker blobSidecarsRequestTracker,
       final RateTracker dataColumnSidecarsRequestTracker,
       final RateTracker requestTracker,
-      final KZG kzg) {
+      final KZG kzg,
+      final MetricsSystem metricsSystem,
+      final TimeProvider timeProvider) {
     return new DefaultEth2Peer(
         spec,
         peer,
@@ -66,7 +70,9 @@ public interface Eth2Peer extends Peer, SyncSource {
         blobSidecarsRequestTracker,
         dataColumnSidecarsRequestTracker,
         requestTracker,
-        kzg);
+        kzg,
+        metricsSystem,
+        timeProvider);
   }
 
   void updateStatus(PeerStatus status);

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerFactory.java
@@ -89,6 +89,8 @@ public class Eth2PeerFactory {
             "dataColumns"),
         RateTracker.create(
             peerRequestLimit * REQUEST_RATE_LIMIT_BOOST, TIME_OUT, timeProvider, "requestTracker"),
-        kzg);
+        kzg,
+        metricsSystem,
+        timeProvider);
   }
 }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxy.java
@@ -16,11 +16,10 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType.DATA_COLUMN_SIDECAR_SLOT_NOT_IN_RANGE;
 import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType.DATA_COLUMN_SIDECAR_UNEXPECTED_IDENTIFIER;
 
+import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
@@ -42,7 +41,6 @@ public class DataColumnSidecarsByRangeListenerValidatingProxy
 
   private final Set<UInt64> columns;
   private final MetricsHistogram dataColumnSidecarInclusionProofVerificationTimeSeconds;
-  private static final Logger LOG = LogManager.getLogger();
 
   public DataColumnSidecarsByRangeListenerValidatingProxy(
       final Spec spec,
@@ -90,10 +88,11 @@ public class DataColumnSidecarsByRangeListenerValidatingProxy
           try (MetricsHistogram.Timer ignored =
               dataColumnSidecarInclusionProofVerificationTimeSeconds.startTimer()) {
             verifyInclusionProof(dataColumnSidecar);
-          } catch (final Throwable t) {
-            LOG.error(
-                "Failed to verify inclusion proof for  data column sidecar {}",
-                dataColumnSidecar.toLogString());
+          } catch (final IOException ioException) {
+            throw new DataColumnSidecarsResponseInvalidResponseException(
+                peer,
+                DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType
+                    .DATA_COLUMN_SIDECAR_INCLUSION_PROOF_VERIFICATION_FAILED);
           }
           verifyKzgProof(dataColumnSidecar);
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRangeListenerValidatingProxy.java
@@ -15,6 +15,7 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType.DATA_COLUMN_SIDECAR_SLOT_NOT_IN_RANGE;
 import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType.DATA_COLUMN_SIDECAR_UNEXPECTED_IDENTIFIER;
+import static tech.pegasys.teku.statetransition.validation.DataColumnSidecarGossipValidator.DATA_COLUMN_SIDECAR_INCLUSION_PROOF_VERIFICATION_HISTOGRAM;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -23,7 +24,6 @@ import java.util.Set;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
 import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
-import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
@@ -58,16 +58,8 @@ public class DataColumnSidecarsByRangeListenerValidatingProxy
     this.endSlot = startSlot.plus(count).minusMinZero(1);
     this.columns = new HashSet<>(columns);
     this.dataColumnSidecarInclusionProofVerificationTimeSeconds =
-        new MetricsHistogram(
-            metricsSystem,
-            timeProvider,
-            TekuMetricCategory.BEACON,
-            "data_column_sidecar_inclusion_proof_verification_seconds",
-            "Time taken to verify data column sidecar inclusion proof",
-            new double[] {
-              0.001, 0.002, 0.003, 0.004, 0.005, 0.01, 0.015, 0.02, 0.025, 0.03, 0.04, 0.05, 0.1,
-              0.5, 1.0
-            });
+        DATA_COLUMN_SIDECAR_INCLUSION_PROOF_VERIFICATION_HISTOGRAM.apply(
+            metricsSystem, timeProvider);
   }
 
   @Override

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxy.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxy.java
@@ -14,7 +14,9 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import java.util.List;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
 import tech.pegasys.teku.networking.p2p.rpc.RpcResponseListener;
@@ -32,8 +34,10 @@ public class DataColumnSidecarsByRootListenerValidatingProxy
       final Spec spec,
       final RpcResponseListener<DataColumnSidecar> listener,
       final KZG kzg,
+      final MetricsSystem metricsSystem,
+      final TimeProvider timeProvider,
       final List<DataColumnIdentifier> expectedDataColumnIdentifiers) {
-    super(peer, spec, kzg, expectedDataColumnIdentifiers);
+    super(peer, spec, kzg, metricsSystem, timeProvider, expectedDataColumnIdentifiers);
     this.listener = listener;
   }
 

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
@@ -15,11 +15,10 @@ package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
 import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
@@ -33,7 +32,6 @@ import tech.pegasys.teku.spec.datastructures.networking.libp2p.rpc.DataColumnIde
 public class DataColumnSidecarsByRootValidator extends AbstractDataColumnSidecarValidator {
   private final Set<DataColumnIdentifier> expectedDataColumnIdentifiers;
   private final MetricsHistogram dataColumnSidecarInclusionProofVerificationTimeSeconds;
-  private static final Logger LOG = LogManager.getLogger();
 
   public DataColumnSidecarsByRootValidator(
       final Peer peer,
@@ -69,10 +67,9 @@ public class DataColumnSidecarsByRootValidator extends AbstractDataColumnSidecar
     try (MetricsHistogram.Timer ignored =
         dataColumnSidecarInclusionProofVerificationTimeSeconds.startTimer()) {
       verifyInclusionProof(dataColumnSidecar);
-    } catch (final Throwable t) {
-      LOG.error(
-          "Failed to verify inclusion proof for  data column sidecar {}",
-          dataColumnSidecar.toLogString());
+    } catch (final IOException ioException) {
+      throw new DataColumnSidecarsResponseInvalidResponseException(
+          peer, InvalidResponseType.DATA_COLUMN_SIDECAR_INCLUSION_PROOF_VERIFICATION_FAILED);
     }
     verifyKzgProof(dataColumnSidecar);
   }

--- a/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
+++ b/networking/eth2/src/main/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootValidator.java
@@ -14,6 +14,7 @@
 package tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods;
 
 import static tech.pegasys.teku.networking.eth2.rpc.beaconchain.methods.DataColumnSidecarsResponseInvalidResponseException.InvalidResponseType;
+import static tech.pegasys.teku.statetransition.validation.DataColumnSidecarGossipValidator.DATA_COLUMN_SIDECAR_INCLUSION_PROOF_VERIFICATION_HISTOGRAM;
 
 import java.io.IOException;
 import java.util.List;
@@ -21,7 +22,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import tech.pegasys.teku.infrastructure.metrics.MetricsHistogram;
-import tech.pegasys.teku.infrastructure.metrics.TekuMetricCategory;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.p2p.peer.Peer;
@@ -44,16 +44,8 @@ public class DataColumnSidecarsByRootValidator extends AbstractDataColumnSidecar
     this.expectedDataColumnIdentifiers = ConcurrentHashMap.newKeySet();
     this.expectedDataColumnIdentifiers.addAll(expectedDataColumnIdentifiers);
     this.dataColumnSidecarInclusionProofVerificationTimeSeconds =
-        new MetricsHistogram(
-            metricsSystem,
-            timeProvider,
-            TekuMetricCategory.BEACON,
-            "data_column_sidecar_inclusion_proof_verification_seconds",
-            "Time taken to verify data column sidecar inclusion proof",
-            new double[] {
-              0.001, 0.002, 0.003, 0.004, 0.005, 0.01, 0.015, 0.02, 0.025, 0.03, 0.04, 0.05, 0.1,
-              0.5, 1.0
-            });
+        DATA_COLUMN_SIDECAR_INCLUSION_PROOF_VERIFICATION_HISTOGRAM.apply(
+            metricsSystem, timeProvider);
   }
 
   public void validate(final DataColumnSidecar dataColumnSidecar) {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
-
 import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/peers/Eth2PeerTest.java
@@ -25,9 +25,12 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
+
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer.PeerStatusSubscriber;
@@ -65,6 +68,8 @@ class Eth2PeerTest {
   private final RateTracker dataColumnSidecarsRateTracker = mock(RateTracker.class);
   private final RateTracker rateTracker = mock(RateTracker.class);
   private final KZG kzg = mock(KZG.class);
+  private final MetricsSystem metricsSystem = mock(MetricsSystem.class);
+  private final TimeProvider timeProvider = mock(TimeProvider.class);
 
   private final PeerStatus randomPeerStatus = randomPeerStatus();
 
@@ -81,7 +86,9 @@ class Eth2PeerTest {
           blobSidecarsRateTracker,
           dataColumnSidecarsRateTracker,
           rateTracker,
-          kzg);
+          kzg,
+          metricsSystem,
+          timeProvider);
 
   @Test
   void updateStatus_shouldNotUpdateUntilValidationPasses() {

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxyTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.metrics.StubMetricsSystem;
+import tech.pegasys.teku.infrastructure.time.StubTimeProvider;
 import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
@@ -51,8 +53,8 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
   private DataColumnSidecarsByRootListenerValidatingProxy listenerWrapper;
   private final Eth2Peer peer = mock(Eth2Peer.class);
   private final KZG kzg = mock(KZG.class);
-  private final MetricsSystem metricsSystem = mock(MetricsSystem.class);
-  private final TimeProvider timeProvider = mock(TimeProvider.class);
+  private final MetricsSystem metricsSystem = new StubMetricsSystem();
+  private final TimeProvider timeProvider = StubTimeProvider.withTimeInMillis(UInt64.ZERO);
 
   @SuppressWarnings("unchecked")
   private final RpcResponseListener<DataColumnSidecar> listener = mock(RpcResponseListener.class);

--- a/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxyTest.java
+++ b/networking/eth2/src/test/java/tech/pegasys/teku/networking/eth2/rpc/beaconchain/methods/DataColumnSidecarsByRootListenerValidatingProxyTest.java
@@ -23,10 +23,12 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
+import org.hyperledger.besu.plugin.services.MetricsSystem;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.pegasys.teku.bls.BLSSignature;
 import tech.pegasys.teku.infrastructure.async.SafeFuture;
+import tech.pegasys.teku.infrastructure.time.TimeProvider;
 import tech.pegasys.teku.infrastructure.unsigned.UInt64;
 import tech.pegasys.teku.kzg.KZG;
 import tech.pegasys.teku.networking.eth2.peers.Eth2Peer;
@@ -49,6 +51,8 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
   private DataColumnSidecarsByRootListenerValidatingProxy listenerWrapper;
   private final Eth2Peer peer = mock(Eth2Peer.class);
   private final KZG kzg = mock(KZG.class);
+  private final MetricsSystem metricsSystem = mock(MetricsSystem.class);
+  private final TimeProvider timeProvider = mock(TimeProvider.class);
 
   @SuppressWarnings("unchecked")
   private final RpcResponseListener<DataColumnSidecar> listener = mock(RpcResponseListener.class);
@@ -76,7 +80,7 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
             new DataColumnIdentifier(block4.getRoot(), UInt64.ZERO));
     listenerWrapper =
         new DataColumnSidecarsByRootListenerValidatingProxy(
-            peer, spec, listener, kzg, dataColumnIdentifiers);
+            peer, spec, listener, kzg, metricsSystem, timeProvider, dataColumnIdentifiers);
 
     final DataColumnSidecar dataColumnSidecar1_0 =
         dataStructureUtil.randomDataColumnSidecarWithInclusionProof(block1, UInt64.ZERO);
@@ -106,7 +110,7 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
             new DataColumnIdentifier(block1.getRoot(), UInt64.ONE));
     listenerWrapper =
         new DataColumnSidecarsByRootListenerValidatingProxy(
-            peer, spec, listener, kzg, dataColumnIdentifiers);
+            peer, spec, listener, kzg, metricsSystem, timeProvider, dataColumnIdentifiers);
 
     final DataColumnSidecar datColumnSidecar1_0 =
         dataStructureUtil.randomDataColumnSidecarWithInclusionProof(block1, UInt64.ZERO);
@@ -136,7 +140,7 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
         new DataColumnIdentifier(block1.getRoot(), UInt64.ZERO);
     listenerWrapper =
         new DataColumnSidecarsByRootListenerValidatingProxy(
-            peer, spec, listener, kzg, List.of(dataColumnIdentifier));
+            peer, spec, listener, kzg, metricsSystem, timeProvider, List.of(dataColumnIdentifier));
 
     final DataColumnSidecar dataColumnSidecar =
         dataStructureUtil.randomDataColumnSidecarWithInclusionProof(
@@ -193,7 +197,7 @@ public class DataColumnSidecarsByRootListenerValidatingProxyTest {
         new DataColumnIdentifier(dataColumnSidecar.getBlockRoot(), UInt64.ZERO);
     listenerWrapper =
         new DataColumnSidecarsByRootListenerValidatingProxy(
-            peer, spec, listener, kzg, List.of(dataColumnIdentifier));
+            peer, spec, listener, kzg, metricsSystem, timeProvider, List.of(dataColumnIdentifier));
 
     final SafeFuture<?> result = listenerWrapper.onResponse(dataColumnSidecar);
     assertThat(result).isCompletedExceptionally();

--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -691,7 +691,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
               gossipValidationHelper,
               MiscHelpersFulu.required(spec.forMilestone(SpecMilestone.FULU).miscHelpers()),
               kzg,
-              metricsSystem);
+              metricsSystem,
+              timeProvider);
       dataColumnSidecarManager =
           new DataColumnSidecarManagerImpl(
               dataColumnSidecarGossipValidator, dasGossipLogger, metricsSystem, timeProvider);


### PR DESCRIPTION
## PR Description

Add `beacon_data_column_sidecar_inclusion_proof_verification_seconds` PeerDAS metric

## Fixed Issue(s)
fixes #65

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
