### PR TITLE
Separate storage for non-canonical datacolumn sidecars

### DIFF
--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -259,6 +259,8 @@ public interface Database extends AutoCloseable {
 
   Optional<DataColumnSidecar> getSidecar(DataColumnSlotAndIdentifier identifier);
 
+  Optional<DataColumnSidecar> getNonCanonicalSidecar(DataColumnSlotAndIdentifier identifier);
+
   @MustBeClosed
   Stream<DataColumnSlotAndIdentifier> streamDataColumnIdentifiers(
       UInt64 firstSlot, UInt64 lastSlot);
@@ -266,6 +268,15 @@ public interface Database extends AutoCloseable {
   @MustBeClosed
   default Stream<DataColumnSlotAndIdentifier> streamDataColumnIdentifiers(final UInt64 slot) {
     return streamDataColumnIdentifiers(slot, slot);
+  }
+
+  @MustBeClosed
+  Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
+          UInt64 firstSlot, UInt64 lastSlot);
+
+  @MustBeClosed
+  default Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(final UInt64 slot) {
+    return streamNonCanonicalDataColumnIdentifiers(slot, slot);
   }
 
   Optional<UInt64> getEarliestDataColumnSidecarSlot();
@@ -276,5 +287,10 @@ public interface Database extends AutoCloseable {
 
   void addSidecar(DataColumnSidecar sidecar);
 
+  void addNonCanonicalSidecar(DataColumnSidecar sidecar);
+
   void pruneAllSidecars(UInt64 tillSlotInclusive);
+
+  void pruneAllNonCanonicalSidecars(UInt64 tillSlotInclusive);
+
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/Database.java
@@ -272,10 +272,11 @@ public interface Database extends AutoCloseable {
 
   @MustBeClosed
   Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
-          UInt64 firstSlot, UInt64 lastSlot);
+      UInt64 firstSlot, UInt64 lastSlot);
 
   @MustBeClosed
-  default Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(final UInt64 slot) {
+  default Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
+      final UInt64 slot) {
     return streamNonCanonicalDataColumnIdentifiers(slot, slot);
   }
 
@@ -292,5 +293,4 @@ public interface Database extends AutoCloseable {
   void pruneAllSidecars(UInt64 tillSlotInclusive);
 
   void pruneAllNonCanonicalSidecars(UInt64 tillSlotInclusive);
-
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/KvStoreDatabase.java
@@ -1126,7 +1126,8 @@ public class KvStoreDatabase implements Database {
   }
 
   @Override
-  public Optional<DataColumnSidecar> getNonCanonicalSidecar(final DataColumnSlotAndIdentifier identifier) {
+  public Optional<DataColumnSidecar> getNonCanonicalSidecar(
+      final DataColumnSlotAndIdentifier identifier) {
     final Optional<Bytes> maybePayload = dao.getNonCanonicalSidecar(identifier);
     return maybePayload.map(payload -> spec.deserializeSidecar(payload, identifier.slot()));
   }
@@ -1141,7 +1142,7 @@ public class KvStoreDatabase implements Database {
   @Override
   @MustBeClosed
   public Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
-          final UInt64 firstSlot, final UInt64 lastSlot) {
+      final UInt64 firstSlot, final UInt64 lastSlot) {
     return dao.streamNonCanonicalDataColumnIdentifiers(firstSlot, lastSlot);
   }
 
@@ -1195,8 +1196,8 @@ public class KvStoreDatabase implements Database {
   @Override
   public void pruneAllNonCanonicalSidecars(final UInt64 tillSlotInclusive) {
     try (final Stream<DataColumnSlotAndIdentifier> prunableIdentifiers =
-                 streamNonCanonicalDataColumnIdentifiers(UInt64.ZERO, tillSlotInclusive);
-         final FinalizedUpdater updater = finalizedUpdater()) {
+            streamNonCanonicalDataColumnIdentifiers(UInt64.ZERO, tillSlotInclusive);
+        final FinalizedUpdater updater = finalizedUpdater()) {
       prunableIdentifiers.forEach(updater::removeNonCanonicalSidecar);
       updater.commit();
     }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -592,11 +592,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   @Override
   @MustBeClosed
   public Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
-          final UInt64 startSlot, final UInt64 endSlot) {
+      final UInt64 startSlot, final UInt64 endSlot) {
     return db.streamKeys(
-            schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
-            new DataColumnSlotAndIdentifier(startSlot, MIN_BLOCK_ROOT, UInt64.ZERO),
-            new DataColumnSlotAndIdentifier(endSlot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE));
+        schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
+        new DataColumnSlotAndIdentifier(startSlot, MIN_BLOCK_ROOT, UInt64.ZERO),
+        new DataColumnSlotAndIdentifier(endSlot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE));
   }
 
   @Override
@@ -928,10 +928,10 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     @Override
     public void addNonCanonicalSidecar(final DataColumnSidecar sidecar) {
       transaction.put(
-              schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
-              new DataColumnSlotAndIdentifier(
-                      sidecar.getSlot(), sidecar.getBlockRoot(), sidecar.getIndex()),
-              sidecar.sszSerialize());
+          schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
+          new DataColumnSlotAndIdentifier(
+              sidecar.getSlot(), sidecar.getBlockRoot(), sidecar.getIndex()),
+          sidecar.sszSerialize());
     }
 
     @Override
@@ -941,8 +941,8 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
 
     @Override
     public void removeNonCanonicalSidecar(final DataColumnSlotAndIdentifier identifier) {
-      transaction.delete(schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(), identifier);
+      transaction.delete(
+          schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(), identifier);
     }
-
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/CombinedKvStoreDao.java
@@ -575,6 +575,11 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
   }
 
   @Override
+  public Optional<Bytes> getNonCanonicalSidecar(final DataColumnSlotAndIdentifier identifier) {
+    return db.get(schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(), identifier);
+  }
+
+  @Override
   @MustBeClosed
   public Stream<DataColumnSlotAndIdentifier> streamDataColumnIdentifiers(
       final UInt64 startSlot, final UInt64 endSlot) {
@@ -582,6 +587,16 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
         schema.getColumnSidecarByColumnSlotAndIdentifier(),
         new DataColumnSlotAndIdentifier(startSlot, MIN_BLOCK_ROOT, UInt64.ZERO),
         new DataColumnSlotAndIdentifier(endSlot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE));
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
+          final UInt64 startSlot, final UInt64 endSlot) {
+    return db.streamKeys(
+            schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
+            new DataColumnSlotAndIdentifier(startSlot, MIN_BLOCK_ROOT, UInt64.ZERO),
+            new DataColumnSlotAndIdentifier(endSlot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE));
   }
 
   @Override
@@ -911,8 +926,23 @@ public class CombinedKvStoreDao<S extends SchemaCombined>
     }
 
     @Override
+    public void addNonCanonicalSidecar(final DataColumnSidecar sidecar) {
+      transaction.put(
+              schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
+              new DataColumnSlotAndIdentifier(
+                      sidecar.getSlot(), sidecar.getBlockRoot(), sidecar.getIndex()),
+              sidecar.sszSerialize());
+    }
+
+    @Override
     public void removeSidecar(final DataColumnSlotAndIdentifier identifier) {
       transaction.delete(schema.getColumnSidecarByColumnSlotAndIdentifier(), identifier);
     }
+
+    @Override
+    public void removeNonCanonicalSidecar(final DataColumnSlotAndIdentifier identifier) {
+      transaction.delete(schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(), identifier);
+    }
+
   }
 }

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -181,7 +181,8 @@ public interface KvStoreCombinedDao extends AutoCloseable {
   Stream<DataColumnSlotAndIdentifier> streamDataColumnIdentifiers(UInt64 startSlot, UInt64 endSlot);
 
   @MustBeClosed
-  Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(UInt64 startSlot, UInt64 endSlot);
+  Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
+      UInt64 startSlot, UInt64 endSlot);
 
   List<DataColumnSlotAndIdentifier> getDataColumnIdentifiers(SlotAndBlockRoot slotAndBlockRoot);
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDao.java
@@ -175,8 +175,13 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
   Optional<Bytes> getSidecar(DataColumnSlotAndIdentifier identifier);
 
+  Optional<Bytes> getNonCanonicalSidecar(DataColumnSlotAndIdentifier identifier);
+
   @MustBeClosed
   Stream<DataColumnSlotAndIdentifier> streamDataColumnIdentifiers(UInt64 startSlot, UInt64 endSlot);
+
+  @MustBeClosed
+  Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(UInt64 startSlot, UInt64 endSlot);
 
   List<DataColumnSlotAndIdentifier> getDataColumnIdentifiers(SlotAndBlockRoot slotAndBlockRoot);
 
@@ -291,7 +296,11 @@ public interface KvStoreCombinedDao extends AutoCloseable {
 
     void addSidecar(DataColumnSidecar sidecar);
 
+    void addNonCanonicalSidecar(DataColumnSidecar sidecar);
+
     void removeSidecar(DataColumnSlotAndIdentifier identifier);
+
+    void removeNonCanonicalSidecar(DataColumnSlotAndIdentifier dataColumnSlotAndIdentifier);
 
     void commit();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -350,7 +350,7 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   @Override
   @MustBeClosed
   public Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
-          final UInt64 startSlot, final UInt64 endSlot) {
+      final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamNonCanonicalDataColumnIdentifiers(startSlot, endSlot);
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/KvStoreCombinedDaoAdapter.java
@@ -336,10 +336,22 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
   }
 
   @Override
+  public Optional<Bytes> getNonCanonicalSidecar(final DataColumnSlotAndIdentifier identifier) {
+    return finalizedDao.getNonCanonicalSidecar(identifier);
+  }
+
+  @Override
   @MustBeClosed
   public Stream<DataColumnSlotAndIdentifier> streamDataColumnIdentifiers(
       final UInt64 startSlot, final UInt64 endSlot) {
     return finalizedDao.streamDataColumnIdentifiers(startSlot, endSlot);
+  }
+
+  @Override
+  @MustBeClosed
+  public Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
+          final UInt64 startSlot, final UInt64 endSlot) {
+    return finalizedDao.streamNonCanonicalDataColumnIdentifiers(startSlot, endSlot);
   }
 
   @Override
@@ -664,8 +676,18 @@ public class KvStoreCombinedDaoAdapter implements KvStoreCombinedDao, V4Migratab
     }
 
     @Override
+    public void addNonCanonicalSidecar(final DataColumnSidecar sidecar) {
+      finalizedUpdater.addNonCanonicalSidecar(sidecar);
+    }
+
+    @Override
     public void removeSidecar(final DataColumnSlotAndIdentifier identifier) {
       finalizedUpdater.removeSidecar(identifier);
+    }
+
+    @Override
+    public void removeNonCanonicalSidecar(final DataColumnSlotAndIdentifier identifier) {
+      finalizedUpdater.removeNonCanonicalSidecar(identifier);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -213,6 +213,10 @@ public class V4FinalizedKvStoreDao {
     return db.get(schema.getColumnSidecarByColumnSlotAndIdentifier(), identifier);
   }
 
+  public Optional<Bytes> getNonCanonicalSidecar(final DataColumnSlotAndIdentifier identifier) {
+    return db.get(schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(), identifier);
+  }
+
   @MustBeClosed
   public Stream<DataColumnSlotAndIdentifier> streamDataColumnIdentifiers(
       final UInt64 startSlot, final UInt64 endSlot) {
@@ -220,6 +224,15 @@ public class V4FinalizedKvStoreDao {
         schema.getColumnSidecarByColumnSlotAndIdentifier(),
         new DataColumnSlotAndIdentifier(startSlot, MIN_BLOCK_ROOT, UInt64.ZERO),
         new DataColumnSlotAndIdentifier(endSlot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE));
+  }
+
+  @MustBeClosed
+  public Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
+          final UInt64 startSlot, final UInt64 endSlot) {
+    return db.streamKeys(
+            schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
+            new DataColumnSlotAndIdentifier(startSlot, MIN_BLOCK_ROOT, UInt64.ZERO),
+            new DataColumnSlotAndIdentifier(endSlot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE));
   }
 
   public List<DataColumnSlotAndIdentifier> getDataColumnIdentifiers(
@@ -490,8 +503,22 @@ public class V4FinalizedKvStoreDao {
     }
 
     @Override
+    public void addNonCanonicalSidecar(final DataColumnSidecar sidecar) {
+        transaction.put(
+            schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
+            new DataColumnSlotAndIdentifier(
+                sidecar.getSlot(), sidecar.getBlockRoot(), sidecar.getIndex()),
+            sidecar.sszSerialize());
+    }
+
+    @Override
     public void removeSidecar(final DataColumnSlotAndIdentifier identifier) {
       transaction.delete(schema.getColumnSidecarByColumnSlotAndIdentifier(), identifier);
+    }
+
+    @Override
+    public void removeNonCanonicalSidecar(final DataColumnSlotAndIdentifier identifier) {
+      transaction.delete(schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(), identifier);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/dataaccess/V4FinalizedKvStoreDao.java
@@ -228,11 +228,11 @@ public class V4FinalizedKvStoreDao {
 
   @MustBeClosed
   public Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
-          final UInt64 startSlot, final UInt64 endSlot) {
+      final UInt64 startSlot, final UInt64 endSlot) {
     return db.streamKeys(
-            schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
-            new DataColumnSlotAndIdentifier(startSlot, MIN_BLOCK_ROOT, UInt64.ZERO),
-            new DataColumnSlotAndIdentifier(endSlot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE));
+        schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
+        new DataColumnSlotAndIdentifier(startSlot, MIN_BLOCK_ROOT, UInt64.ZERO),
+        new DataColumnSlotAndIdentifier(endSlot, MAX_BLOCK_ROOT, UInt64.MAX_VALUE));
   }
 
   public List<DataColumnSlotAndIdentifier> getDataColumnIdentifiers(
@@ -504,11 +504,11 @@ public class V4FinalizedKvStoreDao {
 
     @Override
     public void addNonCanonicalSidecar(final DataColumnSidecar sidecar) {
-        transaction.put(
-            schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
-            new DataColumnSlotAndIdentifier(
-                sidecar.getSlot(), sidecar.getBlockRoot(), sidecar.getIndex()),
-            sidecar.sszSerialize());
+      transaction.put(
+          schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(),
+          new DataColumnSlotAndIdentifier(
+              sidecar.getSlot(), sidecar.getBlockRoot(), sidecar.getIndex()),
+          sidecar.sszSerialize());
     }
 
     @Override
@@ -518,7 +518,8 @@ public class V4FinalizedKvStoreDao {
 
     @Override
     public void removeNonCanonicalSidecar(final DataColumnSlotAndIdentifier identifier) {
-      transaction.delete(schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(), identifier);
+      transaction.delete(
+          schema.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier(), identifier);
     }
 
     @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
@@ -65,6 +65,8 @@ public interface SchemaCombined extends Schema {
 
   KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> getColumnSidecarByColumnSlotAndIdentifier();
 
+  KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> getColumnNonCanonicalSidecarByColumnSlotAndIdentifier();
+
   // Variables
   KvStoreVariable<UInt64> getVariableGenesisTime();
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaCombined.java
@@ -65,7 +65,8 @@ public interface SchemaCombined extends Schema {
 
   KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> getColumnSidecarByColumnSlotAndIdentifier();
 
-  KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> getColumnNonCanonicalSidecarByColumnSlotAndIdentifier();
+  KvStoreColumn<DataColumnSlotAndIdentifier, Bytes>
+      getColumnNonCanonicalSidecarByColumnSlotAndIdentifier();
 
   // Variables
   KvStoreVariable<UInt64> getVariableGenesisTime();

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
@@ -55,6 +55,11 @@ public class SchemaFinalizedSnapshotStateAdapter implements SchemaFinalizedSnaps
     return delegate.getColumnSidecarByColumnSlotAndIdentifier();
   }
 
+  public KvStoreColumn<DataColumnSlotAndIdentifier, Bytes>
+      getColumnNonCanonicalSidecarByColumnSlotAndIdentifier() {
+    return delegate.getColumnNonCanonicalSidecarByColumnSlotAndIdentifier();
+  }
+
   public Map<String, KvStoreColumn<?, ?>> getColumnMap() {
     return ImmutableMap.<String, KvStoreColumn<?, ?>>builder()
         .put("SLOTS_BY_FINALIZED_ROOT", getColumnSlotsByFinalizedRoot())

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/SchemaFinalizedSnapshotStateAdapter.java
@@ -75,6 +75,9 @@ public class SchemaFinalizedSnapshotStateAdapter implements SchemaFinalizedSnaps
             "NON_CANONICAL_BLOB_SIDECAR_BY_SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX",
             getColumnNonCanonicalBlobSidecarBySlotRootBlobIndex())
         .put("SIDECAR_BY_COLUMN_SLOT_AND_IDENTIFIER", getColumnSidecarByColumnSlotAndIdentifier())
+        .put(
+            "NON_CANONICAL_SIDECAR_BY_COLUMN_SLOT_AND_IDENTIFIER",
+            getColumnNonCanonicalSidecarByColumnSlotAndIdentifier())
         .build();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
@@ -50,7 +50,8 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
   private final KvStoreColumn<SlotAndBlockRootAndBlobIndex, Bytes>
       nonCanonicalBlobSidecarBySlotRootBlobIndex;
   private final KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> sidecarByColumnSlotAndIdentifier;
-  private final KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> nonCanonicalSidecarByColumnSlotAndIdentifier;
+  private final KvStoreColumn<DataColumnSlotAndIdentifier, Bytes>
+      nonCanonicalSidecarByColumnSlotAndIdentifier;
   private final List<Bytes> deletedColumnIds;
 
   private V6SchemaCombinedSnapshot(final Spec spec, final int finalizedOffset) {
@@ -92,7 +93,7 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
 
     nonCanonicalSidecarByColumnSlotAndIdentifier =
         KvStoreColumn.create(
-                finalizedOffset + 15, COLUMN_SLOT_AND_IDENTIFIER_KEY_SERIALIZER, BYTES_SERIALIZER);
+            finalizedOffset + 15, COLUMN_SLOT_AND_IDENTIFIER_KEY_SERIALIZER, BYTES_SERIALIZER);
 
     deletedColumnIds =
         List.of(

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
@@ -189,6 +189,9 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
             "NON_CANONICAL_BLOB_SIDECAR_BY_SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX",
             getColumnNonCanonicalBlobSidecarBySlotRootBlobIndex())
         .put("SIDECAR_BY_COLUMN_SLOT_AND_IDENTIFIER", getColumnSidecarByColumnSlotAndIdentifier())
+        .put(
+            "NON_CANONICAL_SIDECAR_BY_COLUMN_SLOT_AND_IDENTIFIER",
+            getColumnNonCanonicalSidecarByColumnSlotAndIdentifier())
         .build();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedSnapshot.java
@@ -50,6 +50,7 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
   private final KvStoreColumn<SlotAndBlockRootAndBlobIndex, Bytes>
       nonCanonicalBlobSidecarBySlotRootBlobIndex;
   private final KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> sidecarByColumnSlotAndIdentifier;
+  private final KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> nonCanonicalSidecarByColumnSlotAndIdentifier;
   private final List<Bytes> deletedColumnIds;
 
   private V6SchemaCombinedSnapshot(final Spec spec, final int finalizedOffset) {
@@ -88,6 +89,10 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
     sidecarByColumnSlotAndIdentifier =
         KvStoreColumn.create(
             finalizedOffset + 14, COLUMN_SLOT_AND_IDENTIFIER_KEY_SERIALIZER, BYTES_SERIALIZER);
+
+    nonCanonicalSidecarByColumnSlotAndIdentifier =
+        KvStoreColumn.create(
+                finalizedOffset + 15, COLUMN_SLOT_AND_IDENTIFIER_KEY_SERIALIZER, BYTES_SERIALIZER);
 
     deletedColumnIds =
         List.of(
@@ -152,6 +157,12 @@ public class V6SchemaCombinedSnapshot extends V6SchemaCombined
   public KvStoreColumn<DataColumnSlotAndIdentifier, Bytes>
       getColumnSidecarByColumnSlotAndIdentifier() {
     return sidecarByColumnSlotAndIdentifier;
+  }
+
+  @Override
+  public KvStoreColumn<DataColumnSlotAndIdentifier, Bytes>
+      getColumnNonCanonicalSidecarByColumnSlotAndIdentifier() {
+    return nonCanonicalSidecarByColumnSlotAndIdentifier;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
@@ -52,6 +52,7 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
   private final KvStoreColumn<SlotAndBlockRootAndBlobIndex, Bytes>
       nonCanonicalBlobSidecarBySlotRootBlobIndex;
   private final KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> sidecarByColumnSlotAndIdentifier;
+  private final KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> nonCanonicalSidecarByColumnSlotAndIdentifier;
   private final List<Bytes> deletedColumnIds;
 
   public V6SchemaCombinedTreeState(final Spec spec) {
@@ -94,6 +95,9 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
     sidecarByColumnSlotAndIdentifier =
         KvStoreColumn.create(
             finalizedOffset + 16, COLUMN_SLOT_AND_IDENTIFIER_KEY_SERIALIZER, BYTES_SERIALIZER);
+    nonCanonicalSidecarByColumnSlotAndIdentifier =
+        KvStoreColumn.create(
+            finalizedOffset + 17, COLUMN_SLOT_AND_IDENTIFIER_KEY_SERIALIZER, BYTES_SERIALIZER);
     deletedColumnIds =
         List.of(
             asColumnId(finalizedOffset + 9),
@@ -159,6 +163,12 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
   public KvStoreColumn<DataColumnSlotAndIdentifier, Bytes>
       getColumnSidecarByColumnSlotAndIdentifier() {
     return sidecarByColumnSlotAndIdentifier;
+  }
+
+  @Override
+  public KvStoreColumn<DataColumnSlotAndIdentifier, Bytes>
+      getColumnNonCanonicalSidecarByColumnSlotAndIdentifier() {
+    return nonCanonicalSidecarByColumnSlotAndIdentifier;
   }
 
   @Override

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
@@ -218,6 +218,9 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
             "NON_CANONICAL_BLOB_SIDECAR_BY_SLOT_AND_BLOCK_ROOT_AND_BLOB_INDEX",
             getColumnNonCanonicalBlobSidecarBySlotRootBlobIndex())
         .put("SIDECAR_BY_COLUMN_SLOT_AND_IDENTIFIER", getColumnSidecarByColumnSlotAndIdentifier())
+        .put(
+            "NON_CANONICAL_SIDECAR_BY_COLUMN_SLOT_AND_IDENTIFIER",
+            getColumnNonCanonicalSidecarByColumnSlotAndIdentifier())
         .build();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/kvstore/schema/V6SchemaCombinedTreeState.java
@@ -52,7 +52,8 @@ public class V6SchemaCombinedTreeState extends V6SchemaCombined implements Schem
   private final KvStoreColumn<SlotAndBlockRootAndBlobIndex, Bytes>
       nonCanonicalBlobSidecarBySlotRootBlobIndex;
   private final KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> sidecarByColumnSlotAndIdentifier;
-  private final KvStoreColumn<DataColumnSlotAndIdentifier, Bytes> nonCanonicalSidecarByColumnSlotAndIdentifier;
+  private final KvStoreColumn<DataColumnSlotAndIdentifier, Bytes>
+      nonCanonicalSidecarByColumnSlotAndIdentifier;
   private final List<Bytes> deletedColumnIds;
 
   public V6SchemaCombinedTreeState(final Spec spec) {

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -367,7 +367,8 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
-  public Optional<DataColumnSidecar> getNonCanonicalSidecar(final DataColumnSlotAndIdentifier identifier) {
+  public Optional<DataColumnSidecar> getNonCanonicalSidecar(
+      final DataColumnSlotAndIdentifier identifier) {
     return Optional.empty();
   }
 

--- a/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
+++ b/storage/src/main/java/tech/pegasys/teku/storage/server/noop/NoOpDatabase.java
@@ -367,8 +367,19 @@ public class NoOpDatabase implements Database {
   }
 
   @Override
+  public Optional<DataColumnSidecar> getNonCanonicalSidecar(final DataColumnSlotAndIdentifier identifier) {
+    return Optional.empty();
+  }
+
+  @Override
   @MustBeClosed
   public Stream<DataColumnSlotAndIdentifier> streamDataColumnIdentifiers(
+      final UInt64 firstSlot, final UInt64 lastSlot) {
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<DataColumnSlotAndIdentifier> streamNonCanonicalDataColumnIdentifiers(
       final UInt64 firstSlot, final UInt64 lastSlot) {
     return Stream.empty();
   }
@@ -388,7 +399,13 @@ public class NoOpDatabase implements Database {
   public void addSidecar(final DataColumnSidecar sidecar) {}
 
   @Override
+  public void addNonCanonicalSidecar(final DataColumnSidecar sidecar) {}
+
+  @Override
   public void pruneAllSidecars(final UInt64 tillSlotInclusive) {}
+
+  @Override
+  public void pruneAllNonCanonicalSidecars(final UInt64 tillSlotInclusive) {}
 
   @Override
   public void close() {}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/ConsenSys/teku/blob/master/CONTRIBUTING.md -->

## PR Description
Allow storing of non canonical blob data columns in a separate DB table.
Part 1 of the fix for https://github.com/Nashatyrev/teku/issues/171

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
