### PR TITLE
Fix concurrent modification

### DIFF
--- a/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
+++ b/ethereum/statetransition/src/main/java/tech/pegasys/teku/statetransition/datacolumns/retriever/SimpleSidecarRetriever.java
@@ -124,10 +124,13 @@ public class SimpleSidecarRetriever
   public void onNewValidatedSidecar(final DataColumnSidecar sidecar) {
     final DataColumnSlotAndIdentifier dataColumnSlotAndIdentifier =
         DataColumnSlotAndIdentifier.fromDataColumn(sidecar);
-    pendingRequests.entrySet().stream()
-        .filter(request -> request.getKey().equals(dataColumnSlotAndIdentifier))
-        .filter(request -> !request.getValue().result.isDone())
-        .forEach(requestEntry -> reqRespCompleted(requestEntry.getValue(), sidecar, null));
+    final List<Map.Entry<DataColumnSlotAndIdentifier, RetrieveRequest>> filteredRequests =
+        pendingRequests.entrySet().stream()
+            .filter(request -> request.getKey().equals(dataColumnSlotAndIdentifier))
+            .filter(request -> !request.getValue().result.isDone())
+            .toList();
+    filteredRequests.forEach(
+        requestEntry -> reqRespCompleted(requestEntry.getValue(), sidecar, null));
   }
 
   private synchronized List<RequestMatch> matchRequestsAndPeers() {


### PR DESCRIPTION
Exception:
```
2025-04-04 14:26:26 2025-04-04 12:26:26.634 INFO  - Validator   *** Published aggregate          Count: 1, Slot: 67, Root: d49dec50cc4fbc70e569ad65dc25baf1ca42c05fc33d391d2af1798a5da43a2b 
2025-04-04 14:26:26 2025-04-04 12:26:26.978 INFO  - Validator   *** Published sync_contribution  Count: 24, Slot: 67, Root: d49dec50cc4fbc70e569ad65dc25baf1ca42c05fc33d391d2af1798a5da43a2b 
2025-04-04 14:26:27 2025-04-04 12:26:27.008 ERROR - Error in callback:  
2025-04-04 14:26:27 java.util.ConcurrentModificationException: null 
2025-04-04 14:26:27 at java.base/java.util.LinkedHashMap$LinkedHashIterator.nextNode(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.LinkedHashMap$LinkedEntryIterator.next(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.Iterator.forEachRemaining(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at tech.pegasys.teku.statetransition.datacolumns.retriever.SimpleSidecarRetriever.onNewValidatedSidecar(SimpleSidecarRetriever.java:130) ~[teku-ethereum-statetransition-develop.jar:25.3.0+232-gdd107a1e7c] 
2025-04-04 14:26:27 at tech.pegasys.teku.statetransition.datacolumns.retriever.RecoveringSidecarRetriever.onNewValidatedSidecar(RecoveringSidecarRetriever.java:97) ~[teku-ethereum-statetransition-develop.jar:25.3.0+232-gdd107a1e7c] 
2025-04-04 14:26:27 at tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarRecoveringCustodyImpl.lambda$initiateRecovery$5(DataColumnSidecarRecoveringCustodyImpl.java:268) ~[teku-ethereum-statetransition-develop.jar:25.3.0+232-gdd107a1e7c] 
2025-04-04 14:26:27 at tech.pegasys.teku.infrastructure.subscribers.Subscribers.lambda$forEach$0(Subscribers.java:98) ~[teku-infrastructure-subscribers-develop.jar:25.3.0+232-gdd107a1e7c] 
2025-04-04 14:26:27 at java.base/java.util.concurrent.ConcurrentHashMap$ValuesView.forEach(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at tech.pegasys.teku.infrastructure.subscribers.Subscribers.forEach(Subscribers.java:95) ~[teku-infrastructure-subscribers-develop.jar:25.3.0+232-gdd107a1e7c] 
2025-04-04 14:26:27 at tech.pegasys.teku.statetransition.datacolumns.DataColumnSidecarRecoveringCustodyImpl.lambda$initiateRecovery$6(DataColumnSidecarRecoveringCustodyImpl.java:267) ~[teku-ethereum-statetransition-develop.jar:25.3.0+232-gdd107a1e7c] 
2025-04-04 14:26:27 at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.ReferencePipeline$2$1.accept(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source) ~[?:?] 
2025-04-04 14:26:27 at java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source) ~[?:?]
```