### PR TITLE
Add validator custody group metrics

### DIFF
--- a/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
+++ b/services/beaconchain/src/main/java/tech/pegasys/teku/services/beaconchain/BeaconChainController.java
@@ -893,7 +893,8 @@ public class BeaconChainController extends Service implements BeaconChainControl
             proposersDataManager,
             eventChannels.getPublisher(CustodyGroupCountChannel.class),
             combinedChainDataClient,
-            totalMyCustodyGroups);
+            totalMyCustodyGroups,
+            metricsSystem);
     eventChannels.subscribe(SlotEventsChannel.class, custodyGroupCountManager);
     this.custodyGroupCountManager = custodyGroupCountManager;
   }


### PR DESCRIPTION
## PR Description
The following PeerDAS metrics added:
- beacon_validator_custody_groups_total
- beacon_backfilled_validator_custody_groups_total

## Fixed Issue(s)

Fixes #65

## Documentation

- [ ] I thought about documentation and added the `doc-change-required` label to this PR if updates are required.

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.
